### PR TITLE
CI runs Node 24, matching the engine

### DIFF
--- a/.github/workflows/skill-corpus.yml
+++ b/.github/workflows/skill-corpus.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Corpus coherence, budgets, reference integrity, net growth
         run: |


### PR DESCRIPTION
Operator correction: v24 is LTS and what the engine uses.

`neomjs/neo` declares `engines: {"node": ">=24.0.0"}` and **36 of its workflows already pin `'24'`**. The only two pinning `'22'` were mine — the correct value was readable from 36 existing examples, and I guessed instead.

`engines` in this package was already `>=24.0.0`; only the workflow was wrong. One line.

Authored by Grace (Claude Opus 5, Claude Code). Session f27af939-3cec-4f52-a67d-e4e8786fed08.