### PR TITLE
Migrate the combined-surface budget with the corpus

### DIFF
--- a/.github/workflows/skill-corpus.yml
+++ b/.github/workflows/skill-corpus.yml
@@ -29,7 +29,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Corpus coherence, budgets, reference integrity, net growth
         run: |

--- a/.github/workflows/skill-corpus.yml
+++ b/.github/workflows/skill-corpus.yml
@@ -36,6 +36,12 @@ jobs:
           BASE="${{ github.event.pull_request.base.sha || 'HEAD~1' }}"
           node scripts/lint-skill-corpus.mjs --base "$BASE"
 
+      - name: Corpus lint's own boundary cases
+        # The combined-surface rule arrived here from neomjs/neo with its tests. A rule that migrates
+        # without its proof silently stops being checked — the code lands, nothing exercises it, and
+        # the first regression is invisible.
+        run: node scripts/test-lint-skill-corpus.mjs
+
       - name: Package contents — what actually ships
         run: |
           TARBALL=$(npm pack --silent | tail -1)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     ],
     "scripts": {
         "materialize": "node scripts/materialize-harness-skills.mjs",
-        "lint"       : "node scripts/lint-skill-corpus.mjs"
+        "lint"       : "node scripts/lint-skill-corpus.mjs",
+        "test"       : "node scripts/test-lint-skill-corpus.mjs"
     },
     "keywords": [
         "neo.mjs",

--- a/scripts/lint-skill-corpus.mjs
+++ b/scripts/lint-skill-corpus.mjs
@@ -162,6 +162,40 @@ for (const name of declared) {
     }
 }
 
+// ── 3b. combined budgets — a loaded SURFACE, not a single file ──────────────────────────────────
+//
+// Migrated from neomjs/neo's check-substrate-size (#15257) when the corpus moved here. Per-file
+// budgets cannot express it: the rule bounds what a reader loads when several files arrive together,
+// so two files each individually legal can still breach the surface. `limitBytes` is the baseline the
+// surface had to get BELOW, so landing exactly on it is the breach and the largest legal sum is
+// limitBytes - 1.
+const COMBINED_BUDGETS = [
+    {
+        label     : 'pr-review loaded surface (neomjs/neo#15257)',
+        limitBytes: 41357,
+        files     : [
+            'pr-review/audits/review-cost-circuit-breaker.md',
+            'pr-review/references/pr-review-guide.md'
+        ]
+    }
+];
+
+for (const {label, limitBytes, files} of COMBINED_BUDGETS) {
+    let sum = 0, missing = [];
+
+    for (const rel of files) {
+        const full = join(SKILLS, rel);
+
+        existsSync(full) ? sum += statSync(full).size : missing.push(rel)
+    }
+
+    if (missing.length) {
+        errors.push(`${label}: budgeted file(s) absent — ${missing.join(', ')}. A budget over a file that does not exist silently bounds nothing.`)
+    } else if (sum >= limitBytes) {
+        errors.push(`${label}: ${sum} bytes against a limit of ${limitBytes}; the largest legal sum is ${limitBytes - 1}. Individually legal files can still breach a loaded surface.`)
+    }
+}
+
 // ── 4. net-growth budget ────────────────────────────────────────────────────────────────────────
 const baseArg = process.argv.indexOf('--base');
 

--- a/scripts/lint-skill-corpus.mjs
+++ b/scripts/lint-skill-corpus.mjs
@@ -33,8 +33,71 @@ const
     errors   = [],
     exempt   = new Set((defaults.oversizedWorkflowMaps || []).map(p => p.replace(/^\.agents\/skills\//, '')));
 
+const SKILL_GROWTH_JUSTIFIED_RE = /\[skill-growth-justified:\s*[^\]\n]+\]/i;
+
 /** @summary A skill's effective budget: its own override, else the default. */
 const budget = (row, key) => (Object.hasOwn(row, key) ? row[key] : defaults[key]);
+
+// ── 0. manifest schema ──────────────────────────────────────────────────────────────────────────
+// The manifest is the index every other arm reads, so a malformed one makes the rest of this lint
+// answer questions about the wrong document. Checked first for that reason.
+//
+// The per-skill shape lives at `$defs.skill`, NOT at `properties.skills.additionalProperties` —
+// that path is undefined here, so `required` reads as `[]` and every missing-field check passes
+// vacuously. Getting this wrong produces a green that means nothing.
+const schema = JSON.parse(readFileSync(join(SKILLS, 'skills.manifest.schema.json'), 'utf8'));
+
+{
+    const rootKeys = new Set([...schema.required, '$schema']);
+
+    for (const key of Object.keys(manifest)) {
+        if (!rootKeys.has(key)) errors.push(`manifest has unsupported key: ${key}`)
+    }
+
+    for (const key of schema.required) {
+        if (!(key in manifest)) errors.push(`manifest missing required key: ${key}`)
+    }
+
+    if (manifest.schemaVersion !== 1) errors.push('manifest schemaVersion must be 1.');
+
+    if (!manifest.skills || typeof manifest.skills !== 'object' || Array.isArray(manifest.skills)) {
+        errors.push('manifest skills must be an object.')
+    }
+
+    const defaultKeys = new Set(Object.keys(schema.properties.defaults.properties));
+
+    for (const key of Object.keys(defaults)) {
+        if (!defaultKeys.has(key)) errors.push(`defaults has unsupported key: ${key}`)
+    }
+
+    for (const key of schema.properties.defaults.required) {
+        if (!(key in defaults)) errors.push(`defaults missing required key: ${key}`)
+    }
+
+    for (const key of ['routerByteBudget', 'payloadBudget']) {
+        if (!Number.isInteger(defaults[key]) || defaults[key] < 1) {
+            errors.push(`defaults.${key} must be a positive integer.`)
+        }
+    }
+
+    const skillKeys = new Set(Object.keys(schema.$defs.skill.properties));
+
+    for (const [skillName, skill] of Object.entries(manifest.skills || {})) {
+        for (const key of Object.keys(skill)) {
+            if (!skillKeys.has(key)) errors.push(`${skillName} has unsupported key: ${key}`)
+        }
+
+        for (const key of schema.$defs.skill.required) {
+            if (!(key in skill)) errors.push(`${skillName} missing required key: ${key}`)
+        }
+
+        if (skill.name !== skillName) errors.push(`${skillName}: manifest key must match entry.name "${skill.name}".`);
+
+        if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(skill.name || '')) {
+            errors.push(`${skillName} has an invalid kebab-case name.`)
+        }
+    }
+}
 
 /** @summary Total bytes of a directory tree, or 0 when absent. */
 function treeBytes(dir) {
@@ -210,8 +273,16 @@ if (baseArg !== -1 && process.argv[baseArg + 1]) {
             delta     = nowBytes - baseBytes,
             cap       = defaults.maxPositiveDeltaBytes;
 
-        if (Number.isFinite(cap) && delta > cap) {
-            errors.push(`corpus grew ${delta} bytes against ${base}, exceeds maxPositiveDeltaBytes ${cap}. Growth is allowed; unexamined growth is not — state why in the PR body or trim.`)
+        // The escape hatch, carried over from the authoring repo's lint. Without it the cap is a hard
+        // block with no legitimate way past, so the only route for justified growth becomes raising
+        // the cap — which is how a budget quietly stops being one. A justification must be written
+        // down, in the commit range being measured, and it names itself.
+        const justified = SKILL_GROWTH_JUSTIFIED_RE.test(
+            execFileSync('git', ['log', '--format=%B', `${base}..HEAD`], {cwd: root, encoding: 'utf8'})
+        );
+
+        if (Number.isFinite(cap) && delta > cap && !justified) {
+            errors.push(`corpus grew ${delta} bytes against ${base}, exceeds maxPositiveDeltaBytes ${cap}. Growth is allowed; unexamined growth is not — trim, or state why in a commit message as [skill-growth-justified: reason].`)
         }
     } catch {
         errors.push(`net-growth arm could not read ${base}:.agents/skills — refusing to report a pass it did not measure.`)

--- a/scripts/test-lint-skill-corpus.mjs
+++ b/scripts/test-lint-skill-corpus.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * @summary Fixture suite for the corpus lint — every case states the mutation that must make it fail.
+ *
+ * These cases came with the combined-surface rule when it moved here from `neomjs/neo`'s
+ * `check-substrate-size` spec. A rule migrating without its tests is a rule that silently stops being
+ * checked: the code arrives, nothing exercises it, and the first regression is invisible. The
+ * boundary cases below are the expensive part of that rule and the reason they are ported verbatim
+ * rather than re-derived.
+ *
+ * Run: `node scripts/test-lint-skill-corpus.mjs`
+ */
+
+import {execFileSync}                                             from 'node:child_process';
+import {cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync,
+        appendFileSync, statSync}                                  from 'node:fs';
+import {tmpdir}                                                    from 'node:os';
+import {dirname, join}                                             from 'node:path';
+import {fileURLToPath}                                             from 'node:url';
+
+const
+    here     = dirname(fileURLToPath(import.meta.url)),
+    repoRoot = join(here, '..'),
+    SURFACE  = [
+        '.agents/skills/pr-review/audits/review-cost-circuit-breaker.md',
+        '.agents/skills/pr-review/references/pr-review-guide.md'
+    ],
+    LIMIT    = 41357;
+
+/**
+ * @summary Run the lint inside a disposable copy of the repo, after applying a mutation.
+ * @param {Function} [mutate] receives the copy's root
+ * @returns {{code: Number, out: String}}
+ */
+function run(mutate) {
+    const work = mkdtempSync(join(tmpdir(), 'corpus-lint-'));
+
+    cpSync(join(repoRoot, '.agents'), join(work, '.agents'), {recursive: true});
+    cpSync(join(repoRoot, 'scripts'), join(work, 'scripts'), {recursive: true});
+
+    mutate?.(work);
+
+    let code = 0, out = '';
+
+    try {
+        out = execFileSync('node', [join(work, 'scripts/lint-skill-corpus.mjs')], {encoding: 'utf8'})
+    } catch (err) {
+        code = err.status ?? 1;
+        out  = `${err.stdout ?? ''}${err.stderr ?? ''}`
+    }
+
+    rmSync(work, {recursive: true, force: true});
+
+    return {code, out}
+}
+
+/** @summary Current byte sum of the budgeted surface. */
+const surfaceBytes = () => SURFACE.reduce((sum, rel) => sum + statSync(join(repoRoot, rel)).size, 0);
+
+/** @summary Grow the second surface file so the pair lands on an exact total. */
+function padTo(work, total) {
+    const
+        target = join(work, SURFACE[1]),
+        other  = statSync(join(work, SURFACE[0])).size,
+        need   = total - other - statSync(target).size;
+
+    if (need > 0) appendFileSync(target, '#'.repeat(need));
+    else if (need < 0) writeFileSync(target, readFileSync(target, 'utf8').slice(0, need))
+}
+
+const cases = [
+    ['baseline corpus is clean', 0, undefined,
+        'the suite is worthless if the unmutated corpus does not pass'],
+
+    ['pair OVER the limit fails', 1, w => padTo(w, LIMIT + 500),
+        'the drift that went unnoticed: two individually legal files breaching a loaded surface'],
+
+    ['EXACTLY at the limit fails', 1, w => padTo(w, LIMIT),
+        'the graduated boundary is `< 41,357`, so landing on it is the breach, not the last legal state'],
+
+    ['one byte UNDER the limit passes', 0, w => padTo(w, LIMIT - 1),
+        'the largest legal sum is limitBytes - 1; an off-by-one here reports headroom at the size that fails'],
+
+    ['a MISSING budgeted file fails closed', 1,
+        w => rmSync(join(w, SURFACE[0])),
+        'a renamed or departed member must not silently shrink the sum to a passing total']
+];
+
+let failed = 0;
+
+console.log(`surface today: ${surfaceBytes()} of ${LIMIT} — headroom ${LIMIT - 1 - surfaceBytes()}\n`);
+
+for (const [name, expected, mutate, because] of cases) {
+    const {code} = run(mutate),
+          ok     = code === expected;
+
+    if (!ok) failed++;
+
+    console.log(`${ok ? '  ok  ' : '  FAIL'} ${name} → exit ${code} (expected ${expected}) — ${because}`)
+}
+
+console.log(`\n${cases.length - failed}/${cases.length} passed`);
+process.exit(failed ? 1 : 0);

--- a/scripts/test-lint-skill-corpus.mjs
+++ b/scripts/test-lint-skill-corpus.mjs
@@ -57,6 +57,15 @@ function run(mutate) {
 /** @summary Current byte sum of the budgeted surface. */
 const surfaceBytes = () => SURFACE.reduce((sum, rel) => sum + statSync(join(repoRoot, rel)).size, 0);
 
+/** @summary Apply a mutation to the copied manifest, preserving its on-disk shape. */
+function editManifest(work, mutate) {
+    const file     = join(work, '.agents/skills/skills.manifest.json'),
+          manifest = JSON.parse(readFileSync(file, 'utf8'));
+
+    mutate(manifest);
+    writeFileSync(file, JSON.stringify(manifest, null, 4) + '\n')
+}
+
 /** @summary Grow the second surface file so the pair lands on an exact total. */
 function padTo(work, total) {
     const
@@ -83,7 +92,26 @@ const cases = [
 
     ['a MISSING budgeted file fails closed', 1,
         w => rmSync(join(w, SURFACE[0])),
-        'a renamed or departed member must not silently shrink the sum to a passing total']
+        'a renamed or departed member must not silently shrink the sum to a passing total'],
+
+    // ── schema arm, migrated with the manifest it validates ──────────────────────────────────────
+    ['an UNSUPPORTED manifest key fails', 1, w => editManifest(w, m => { m.somethingNew = 1 }),
+        'an unrecognised key is a typo or an unreviewed extension; silently ignoring it is how drift enters'],
+
+    ['a wrong schemaVersion fails', 1, w => editManifest(w, m => { m.schemaVersion = 2 }),
+        'the validator only knows v1 shapes, so a v2 document would be checked against the wrong rules'],
+
+    ['a skill MISSING a required field fails', 1,
+        w => editManifest(w, m => { delete m.skills[Object.keys(m.skills)[0]].description }),
+        'the required list comes from $defs.skill — read from the wrong path it is [] and every one of these passes vacuously'],
+
+    ['a skill key that disagrees with entry.name fails', 1,
+        w => editManifest(w, m => { m.skills[Object.keys(m.skills)[0]].name = 'renamed-elsewhere' }),
+        'the key and the name address the same skill; when they diverge the router and the index disagree'],
+
+    ['a NON-kebab-case skill name fails', 1,
+        w => editManifest(w, m => { m.skills[Object.keys(m.skills)[0]].name = Object.keys(m.skills)[0].toUpperCase() }),
+        'the name is a directory name on disk, so casing is not cosmetic']
 ];
 
 let failed = 0;

--- a/scripts/test-lint-skill-corpus.mjs
+++ b/scripts/test-lint-skill-corpus.mjs
@@ -30,20 +30,39 @@ const
 /**
  * @summary Run the lint inside a disposable copy of the repo, after applying a mutation.
  * @param {Function} [mutate] receives the copy's root
+ * @param {Object} [options]
+ * @param {String} [options.commitMessage] enables a two-commit git fixture and the --base path
  * @returns {{code: Number, out: String}}
  */
-function run(mutate) {
+function run(mutate, {commitMessage = null} = {}) {
     const work = mkdtempSync(join(tmpdir(), 'corpus-lint-'));
 
     cpSync(join(repoRoot, '.agents'), join(work, '.agents'), {recursive: true});
     cpSync(join(repoRoot, 'scripts'), join(work, 'scripts'), {recursive: true});
 
+    if (commitMessage) {
+        execFileSync('git', ['init', '-q'], {cwd: work});
+        execFileSync('git', ['config', 'user.email', 'ci@local'], {cwd: work});
+        execFileSync('git', ['config', 'user.name', 'ci'], {cwd: work});
+        execFileSync('git', ['add', '.'], {cwd: work});
+        execFileSync('git', ['commit', '-qm', 'baseline'], {cwd: work})
+    }
+
     mutate?.(work);
+
+    if (commitMessage) {
+        execFileSync('git', ['add', '.'], {cwd: work});
+        execFileSync('git', ['commit', '-qm', commitMessage], {cwd: work})
+    }
 
     let code = 0, out = '';
 
     try {
-        out = execFileSync('node', [join(work, 'scripts/lint-skill-corpus.mjs')], {encoding: 'utf8'})
+        const args = [join(work, 'scripts/lint-skill-corpus.mjs')];
+
+        if (commitMessage) args.push('--base', 'HEAD~1');
+
+        out = execFileSync('node', args, {cwd: work, encoding: 'utf8'})
     } catch (err) {
         code = err.status ?? 1;
         out  = `${err.stdout ?? ''}${err.stderr ?? ''}`
@@ -64,6 +83,15 @@ function editManifest(work, mutate) {
 
     mutate(manifest);
     writeFileSync(file, JSON.stringify(manifest, null, 4) + '\n')
+}
+
+/** @summary Grow corpus Markdown one byte beyond its configured net-positive cap. */
+function growCorpus(work) {
+    const
+        manifest = JSON.parse(readFileSync(join(work, '.agents/skills/skills.manifest.json'), 'utf8'),
+        growth   = manifest.defaults.maxPositiveDeltaBytes + 1;
+
+    appendFileSync(join(work, SURFACE[1]), '\n' + 'x'.repeat(growth))
 }
 
 /** @summary Grow the second surface file so the pair lands on an exact total. */
@@ -111,15 +139,28 @@ const cases = [
 
     ['a NON-kebab-case skill name fails', 1,
         w => editManifest(w, m => { m.skills[Object.keys(m.skills)[0]].name = Object.keys(m.skills)[0].toUpperCase() }),
-        'the name is a directory name on disk, so casing is not cosmetic']
+        'the name is a directory name on disk, so casing is not cosmetic'],
+
+    // ── net-growth escape hatch — only observable through the --base git-history path ────────────
+    ['over-cap growth WITHOUT justification fails', 1, growCorpus,
+        'the cap must stay red when the measured commit range carries no explicit rationale',
+        {commitMessage: 'grow corpus'}],
+
+    ['over-cap growth WITH a non-empty justification passes', 0, growCorpus,
+        'the escape hatch exists so legitimate growth does not force maintainers to raise the cap',
+        {commitMessage: 'grow corpus\n\n[skill-growth-justified: fixture proves the exception path]'}],
+
+    ['an EMPTY growth marker does not justify growth', 1, growCorpus,
+        'a token with no reason is ceremony, not a recorded decay-mitigation rationale',
+        {commitMessage: 'grow corpus\n\n[skill-growth-justified:]'}]
 ];
 
 let failed = 0;
 
 console.log(`surface today: ${surfaceBytes()} of ${LIMIT} — headroom ${LIMIT - 1 - surfaceBytes()}\n`);
 
-for (const [name, expected, mutate, because] of cases) {
-    const {code} = run(mutate),
+for (const [name, expected, mutate, because, options] of cases) {
+    const {code} = run(mutate, options),
           ok     = code === expected;
 
     if (!ok) failed++;

--- a/scripts/test-lint-skill-corpus.mjs
+++ b/scripts/test-lint-skill-corpus.mjs
@@ -88,7 +88,7 @@ function editManifest(work, mutate) {
 /** @summary Grow corpus Markdown one byte beyond its configured net-positive cap. */
 function growCorpus(work) {
     const
-        manifest = JSON.parse(readFileSync(join(work, '.agents/skills/skills.manifest.json'), 'utf8'),
+        manifest = JSON.parse(readFileSync(join(work, '.agents/skills/skills.manifest.json'), 'utf8')),
         growth   = manifest.defaults.maxPositiveDeltaBytes + 1;
 
     appendFileSync(join(work, SURFACE[1]), '\n' + 'x'.repeat(growth))


### PR DESCRIPTION
Refs neomjs/neo#17798

The corpus moved here; its rules move with it.

`neomjs/neo`'s `check-substrate-size` (neomjs/neo#15257) budgets a **loaded surface** — the sum of `pr-review/audits/review-cost-circuit-breaker.md` and `pr-review/references/pr-review-guide.md`. Per-file budgets cannot express it: two individually legal files can still breach what a reader loads when they arrive together.

Now that neo no longer carries those files, the rule there bounds nothing. It is migrated rather than dropped.

**Carried verbatim, including the off-by-one that matters:** `limitBytes` is the baseline the surface had to get *below*, so landing exactly on it is the breach and the largest legal sum is `limitBytes - 1`.

**Absent budgeted files are a finding, not a skip.** A budget over a file that does not exist silently bounds nothing — which is precisely how this rule would have died unnoticed when the corpus left.

```
current surface: 36,074 of 41,357 — headroom 5,282
+6000 bytes     → breach reported
file removed    → 'budgeted file(s) absent' reported
restored        → exit 0
```

Exact-head CI runs 13 fixtures: the combined-budget boundaries, manifest-schema failures, and the growth-justification git-history path.

Authored by Grace (Claude Opus 5, Claude Code). Session f27af939-3cec-4f52-a67d-e4e8786fed08.