### PR TITLE
feat(ci): publish reusable PR baseline (#15)

### DIFF
--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -1,0 +1,56 @@
+# Canonical non-product PR baseline for repositories consuming neo-agent-skills.
+#
+# Callers own only their event trigger and immutable `uses:` coordinate. This workflow owns the
+# executable jobs, so adding another consumer does not add another copy of either contract.
+
+name: Reusable PR Baseline
+
+permissions:
+  contents: read
+
+on:
+  workflow_call:
+    inputs:
+      required_base:
+        description: Pull-request base branch accepted by the consumer repository.
+        required: false
+        type: string
+        default: dev
+      node_version:
+        description: Node.js version used to install and verify the consumer lockfile.
+        required: false
+        type: string
+        default: '24'
+
+jobs:
+  pr-base:
+    name: PR base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject a non-PR caller or the wrong base
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.base.ref != inputs.required_base }}
+        env:
+          ACTUAL_BASE: ${{ github.event.pull_request.base.ref }}
+          EXPECTED_BASE: ${{ inputs.required_base }}
+        run: |
+          echo "Expected PR base '${EXPECTED_BASE}', observed '${ACTUAL_BASE:-not-a-pull-request}'."
+          exit 1
+
+  skills-materialized:
+    name: Skills materialized
+    runs-on: ubuntu-latest
+    steps:
+      # With no repository override, checkout resolves the caller repository. The reusable workflow
+      # must inspect the consumer lockfile and projection, never its own source checkout.
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: npm
+
+      - name: Install consumer dependencies
+        run: npm ci
+
+      - name: Assert skills are materialized and unshadowed
+        run: npx --no-install neo-agent-skills-materialize --check

--- a/.github/workflows/skill-corpus.yml
+++ b/.github/workflows/skill-corpus.yml
@@ -1,11 +1,12 @@
-# The canonical anti-bloat CI. It runs HERE and nowhere else.
+# The canonical Skills-source CI. Corpus rules run HERE and nowhere else; reusable consumer
+# workflows also live here, while each consumer commits only a pinned caller.
 #
 # 96% of this package is the skill corpus, so the corpus is what is worth protecting. Consuming
-# repositories run exactly one check — `materialize --check` — because a rule enforced in N repos is
-# N places to drift. One enforcement site is the point.
+# repositories run `materialize --check` through the reusable PR baseline because a rule enforced in
+# N workflow copies is N places to drift. One implementation site is the point.
 #
 # Deliberately absent: identity-roster and revalidation checks, consumer byte-drift, AGENTS
-# entrypoint budgets, downstream doc targets, Playwright, and any reusable consumer workflow.
+# entrypoint budgets, downstream doc targets, Playwright, and product-specific test/lint workflows.
 
 name: skill-corpus
 
@@ -42,6 +43,9 @@ jobs:
         # the first regression is invisible.
         run: node scripts/test-lint-skill-corpus.mjs
 
+      - name: Reusable PR baseline contract
+        run: node scripts/test-reusable-pr-baseline.mjs
+
       - name: Package contents — what actually ships
         run: |
           TARBALL=$(npm pack --silent | tail -1)
@@ -53,7 +57,7 @@ jobs:
           tar tzf "$TARBALL" | grep -q 'package/scripts/materialize-harness-skills.mjs' \
             || { echo "materializer missing from the tarball"; exit 1; }
 
-          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs'; do
+          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs'; do
             tar tzf "$TARBALL" | grep -q "$unwanted" \
               && { echo "$unwanted ships to consumers and should not"; exit 1; }
           done

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+/**
+ * @summary Mutation-sensitive contract checks for the reusable consumer PR baseline.
+ *
+ * GitHub validates YAML syntax when the branch is published; this suite protects the semantic
+ * boundary that syntax cannot: one workflow-call entrypoint, read-only permissions, two stable
+ * jobs, caller-repository checkout, the explicit dev-base decision, and the supported materializer
+ * command. Each negative fixture removes one of those properties and must turn red.
+ *
+ * Run: `node scripts/test-reusable-pr-baseline.mjs`
+ */
+
+import assert          from 'node:assert/strict';
+import {readFileSync}  from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const
+    here         = dirname(fileURLToPath(import.meta.url)),
+    workflowPath = join(here, '..', '.github', 'workflows', 'reusable-pr-baseline.yml');
+
+/**
+ * @summary Returns named semantic-contract violations in one reusable-workflow source string.
+ * @param {String} source
+ * @returns {String[]}
+ */
+export function validateReusablePrBaseline(source) {
+    const failures = [],
+          required = [
+              ['workflow-call trigger', /^on:\n  workflow_call:\n/m],
+              ['read-only contents', /^permissions:\n  contents: read\n/m],
+              ['PR-base job id', /^  pr-base:\n/m],
+              ['PR-base stable name', /^    name: PR base\n/m],
+              ['Skills job id', /^  skills-materialized:\n/m],
+              ['Skills stable name', /^    name: Skills materialized\n/m],
+              ['required_base default', /^      required_base:\n[\s\S]*?^        default: dev\n/m],
+              ['non-PR refusal', /github\.event_name != 'pull_request'/],
+              ['base mismatch refusal', /github\.event\.pull_request\.base\.ref != inputs\.required_base/],
+              ['caller checkout', /uses: actions\/checkout@v4/],
+              ['Node input', /node-version: \$\{\{ inputs\.node_version \}\}/],
+              ['lockfile install', /run: npm ci/],
+              ['materializer check', /run: npx --no-install neo-agent-skills-materialize --check/]
+          ];
+
+    required.forEach(([label, pattern]) => {
+        if (!pattern.test(source)) failures.push(`missing ${label}`)
+    });
+
+    const triggerBlock = source.match(/^on:\n([\s\S]*?)\njobs:/m)?.[1] || '';
+
+    if (!triggerBlock || /^  (?:pull_request|pull_request_target|push|workflow_dispatch|schedule):/m.test(triggerBlock)) {
+        failures.push('direct event trigger present')
+    }
+    if (/^\s+repository:/m.test(source)) failures.push('checkout repository override present');
+    if (/^\s+[a-z_-]+: write\s*$/m.test(source)) failures.push('write permission present');
+
+    return failures
+}
+
+/** @summary Requires one mutation to violate the named semantic contract. */
+function expectMutationFailure(label, source, mutate, expectedFailure) {
+    const mutated  = mutate(source),
+          failures = validateReusablePrBaseline(mutated);
+
+    assert.notEqual(mutated, source, `${label}: fixture mutation changed nothing`);
+    assert.ok(failures.includes(expectedFailure), `${label}: expected "${expectedFailure}", got ${failures.join(', ')}`)
+}
+
+const source = readFileSync(workflowPath, 'utf8');
+
+assert.deepEqual(validateReusablePrBaseline(source), [], 'canonical reusable workflow violates its own contract');
+
+expectMutationFailure('trigger', source,
+    value => value.replace('  workflow_call:', '  pull_request:'),
+    'missing workflow-call trigger');
+expectMutationFailure('permissions', source,
+    value => value.replace('contents: read', 'contents: write'),
+    'missing read-only contents');
+expectMutationFailure('base job', source,
+    value => value.replace('  pr-base:', '  removed-base:'),
+    'missing PR-base job id');
+expectMutationFailure('base decision', source,
+    value => value.replace("github.event_name != 'pull_request'", 'false'),
+    'missing non-PR refusal');
+expectMutationFailure('Skills job', source,
+    value => value.replace('  skills-materialized:', '  removed-skills:'),
+    'missing Skills job id');
+expectMutationFailure('caller checkout', source,
+    value => value.replace('      - uses: actions/checkout@v4', '      - uses: actions/checkout@v4\n        with:\n          repository: neomjs/neo-agent-skills'),
+    'checkout repository override present');
+expectMutationFailure('materializer command', source,
+    value => value.replace('neo-agent-skills-materialize --check', 'neo-agent-skills-materialize'),
+    'missing materializer check');
+
+console.log('reusable-pr-baseline: canonical contract + 7 negative mutations passed');


### PR DESCRIPTION
Resolves #15
Related: #14

Publishes the first Skills-owned reusable consumer workflow: one pinned caller can now receive independent `PR base` and `Skills materialized` jobs without copying either implementation. The Skills source CI now protects that workflow with seven mutation-sensitive contract arms while keeping CI/test internals out of the npm package.

Evidence: L2 (focused contract mutations, full corpus suite, check-only preflight, and package dry-run) → L2 required (this leaf publishes the reusable source; live consumer execution and required-context binding are separate Epic leaves). Residual: none.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | `.github/workflows/reusable-pr-baseline.yml` exposes only `workflow_call`; top-level permissions are `contents: read`. |
| AC-2 | The reusable workflow exposes stable `PR base` and `Skills materialized` job names. |
| AC-3 | `required_base` defaults to `dev`; the base job fails for a non-PR event or mismatched base. |
| AC-4 | The materialization job checks out the caller, selects Node 24, runs `npm ci`, then `neo-agent-skills-materialize --check`. |
| AC-5 | `test-reusable-pr-baseline.mjs` passes the canonical source plus seven negative mutations; `skill-corpus.yml` runs it. |
| AC-6 | `npm pack --dry-run --json` contains neither `.github/**` nor the workflow contract test. |
| AC-7 | The diff touches only the Skills repository; no consumer caller is included. |

## Deltas from ticket

None substantive. Input identifiers use underscore names so GitHub expression dot access remains valid.

## Test Evidence

All coverage runs in CI.

## Post-Merge Validation

No post-merge-only validation for #15. Cross-repository execution belongs to the first consumer-caller leaf under Epic #14.

Authored by Emmy (GPT-5.6 Sol Ultra, Codex). Session f6ad5621-a6d8-4636-bcf6-5fdab898bed0.
