### PR TITLE
feat(ci): share source-comment archaeology guard (#18)

### DIFF
--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -1,7 +1,7 @@
 # Canonical non-product PR baseline for repositories consuming neo-agent-skills.
 #
 # Callers own only their event trigger and immutable `uses:` coordinate. This workflow owns the
-# executable jobs, so adding another consumer does not add another copy of either contract.
+# executable jobs, so adding another consumer does not copy any contract.
 
 name: Reusable PR Baseline
 
@@ -54,3 +54,42 @@ jobs:
 
       - name: Assert skills are materialized and unshadowed
         run: npx --no-install neo-agent-skills-materialize --check
+
+  source-comment-archaeology:
+    name: Source comment archaeology
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject a non-PR caller
+        if: ${{ github.event_name != 'pull_request' }}
+        run: exit 1
+
+      - name: Checkout exact caller head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      - name: Fetch pull-request base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: git fetch --no-tags origin "${BASE_SHA}"
+
+      - name: Install immutable archaeology guard
+        env:
+          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology
+          SKILLS_VERSION: '0.1.2'
+        run: >-
+          npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
+          "neo-agent-skills@${SKILLS_VERSION}"
+
+      - name: Reject tracking and review archaeology
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology
+        run: >-
+          "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-ticket-archaeology"
+          --base "${BASE_SHA}"

--- a/.github/workflows/skill-corpus.yml
+++ b/.github/workflows/skill-corpus.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install source dependencies
+        run: npm ci --ignore-scripts
+
       - name: Corpus coherence, budgets, reference integrity, net growth
         run: |
           BASE="${{ github.event.pull_request.base.sha || 'HEAD~1' }}"
@@ -46,18 +49,23 @@ jobs:
       - name: Reusable PR baseline contract
         run: node scripts/test-reusable-pr-baseline.mjs
 
+      - name: Ticket archaeology contract and packed CLI
+        run: node scripts/test-ticket-archaeology.mjs
+
       - name: Package contents — what actually ships
         run: |
           TARBALL=$(npm pack --silent | tail -1)
 
-          # The corpus must ship; the tooling that guards it must not. A consumer downloading this
-          # package should receive skills, one linker, and nothing else.
+          # The corpus, materializer and portable source guard ship. Source-only CI and contract tests
+          # do not.
           tar tzf "$TARBALL" | grep -q 'package/.agents/skills/skills.manifest.json' \
             || { echo "manifest missing from the tarball"; exit 1; }
           tar tzf "$TARBALL" | grep -q 'package/scripts/materialize-harness-skills.mjs' \
             || { echo "materializer missing from the tarball"; exit 1; }
+          tar tzf "$TARBALL" | grep -q 'package/scripts/check-ticket-archaeology.mjs' \
+            || { echo "ticket-archaeology CLI missing from the tarball"; exit 1; }
 
-          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs'; do
+          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs' 'package/scripts/test-ticket-archaeology.mjs'; do
             tar tzf "$TARBALL" | grep -q "$unwanted" \
               && { echo "$unwanted ships to consumers and should not"; exit 1; }
           done

--- a/README.md
+++ b/README.md
@@ -53,12 +53,27 @@ One measured npm behaviour worth knowing: **`npm install <pkg>` does not run you
 a bare `npm install` does.** So the command that bumps this dependency leaves the links stale until
 the next install. `--check` is what turns that from silent into loud.
 
+## Shared source-comment guard
+
+```bash
+npx --no-install neo-agent-skills-ticket-archaeology --base origin/dev
+```
+
+The guard scans every changed tracked `.mjs` file in full. Repository-local issue numbers of any
+length and review-history markers fail only in comments or JSDoc; executable strings remain valid.
+Ambiguous numeric CSS colors require the token-scoped `[not-ticket-ref: css-color]` marker. Consumer
+repositories call the stable `Source comment archaeology` job in
+`.github/workflows/reusable-pr-baseline.yml` through an immutable Skills revision. That job installs
+its exact guard release outside the caller workspace, so a pull request cannot weaken its own gate by
+changing the caller lockfile or local binary.
+
 ## What is in the package
 
 | path | what |
 |---|---|
 | `.agents/skills/` | the substrate — skills plus `skills.manifest.json` and its schema |
 | `scripts/materialize-harness-skills.mjs` | the postinstall linker and its `--check` arm |
+| `scripts/check-ticket-archaeology.mjs` | the portable comment/JSDoc archaeology guard |
 
 The manifest governs **projection**: a skill declaring `claudeSymlinkRequired: false` is a declared
 opt-out and is correctly absent from the façade. Per-skill links rather than one directory link,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+    "name": "neo-agent-skills",
+    "version": "0.1.2",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "neo-agent-skills",
+            "version": "0.1.2",
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.18.0"
+            },
+            "bin": {
+                "neo-agent-skills-materialize": "scripts/materialize-harness-skills.mjs",
+                "neo-agent-skills-ticket-archaeology": "scripts/check-ticket-archaeology.mjs"
+            },
+            "engines": {
+                "node": ">=24.0.0"
+            }
+        },
+        "node_modules/acorn": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -15,8 +15,12 @@
     "engines": {
         "node": ">=24.0.0"
     },
+    "dependencies": {
+        "acorn": "^8.18.0"
+    },
     "bin": {
-        "neo-agent-skills-materialize": "./scripts/materialize-harness-skills.mjs"
+        "neo-agent-skills-materialize"         : "./scripts/materialize-harness-skills.mjs",
+        "neo-agent-skills-ticket-archaeology" : "./scripts/check-ticket-archaeology.mjs"
     },
     "exports": {
         "./manifest"    : "./.agents/skills/skills.manifest.json",
@@ -25,12 +29,13 @@
     "files": [
         ".agents/skills",
         "scripts/materialize-harness-skills.mjs",
+        "scripts/check-ticket-archaeology.mjs",
         "README.md"
     ],
     "scripts": {
         "materialize": "node scripts/materialize-harness-skills.mjs",
         "lint"       : "node scripts/lint-skill-corpus.mjs",
-        "test"       : "node scripts/test-lint-skill-corpus.mjs"
+        "test"       : "node scripts/test-lint-skill-corpus.mjs && node scripts/test-reusable-pr-baseline.mjs && node scripts/test-ticket-archaeology.mjs"
     },
     "keywords": [
         "neo.mjs",

--- a/scripts/check-ticket-archaeology.mjs
+++ b/scripts/check-ticket-archaeology.mjs
@@ -1,0 +1,270 @@
+#!/usr/bin/env node
+/**
+ * @summary Rejects tracking and review archaeology in durable JavaScript comments.
+ *
+ * The command runs in a consuming repository, not in this package checkout. It scans every selected
+ * tracked `.mjs` file in full so touching a file also retires older archaeology in that file.
+ * String literals remain valid homes for executable fixtures and URLs; comments and JSDoc must
+ * describe current behavior instead of the process that produced it.
+ */
+
+import {parse}                         from 'acorn';
+import {execFileSync}                  from 'node:child_process';
+import {readFileSync, realpathSync}    from 'node:fs';
+import {isAbsolute, relative, resolve} from 'node:path';
+import process                         from 'node:process';
+import {parseArgs}                     from 'node:util';
+import {fileURLToPath}                 from 'node:url';
+
+export const DEFAULT_IGNORES = Object.freeze([
+    '.git', 'coverage', 'dist', 'dist-artifacts', 'node_modules'
+]);
+
+const
+    NAMED_TRACKING_PATTERNS = Object.freeze([
+        /\b(?:issue|ticket|bug|PR|pull[ -]request|Epic|Discussion)\s*(?:[:=]\s*)?#?\s*\d+\b/i,
+        /\bADR[-\s]?\d+\b/i
+    ]),
+    REVIEW_ARCHAEOLOGY_PATTERNS = Object.freeze([
+        /\bRA[-\s]?\d+\b/i,
+        /\b(?:review|PR)\s+(?:round|cycle)\s*#?\d+\b/i,
+        /\b(?:first|second|third|previous|prior)\s+review\s+(?:round|cycle)\b/i,
+        /\bround\s*#?\d+\s+(?:review|reviewer|approval|disposition|requested?\s+changes?)\b/i,
+        /\bround\s*#?\d+\b[^\n]{0,100}\b(?:approved|reviewed|shipped|stayed\s+green)\b/i,
+        /\b(?:earlier|previous|prior)\s+rounds?\b/i
+    ]),
+    NUMERIC_REF_RE = /#(\d+)(?![A-Za-z0-9_])/g,
+    CSS_COLOR_ESCAPE_RE = /#(\d{3}|\d{4}|\d{6}|\d{8})\s*\[not-ticket-ref:\s*css-color\]/gi,
+    CSS_COLOR_CONTEXT_RE = /(?:\bCSS\s+color\b|\b(?:background(?:-color)?|border(?:-color)?|color|fill|stroke)\s*(?::|=))\s*$/i,
+    ANY_TYPED_ESCAPE_RE = /\[not-ticket-ref:[^\]]*\]/gi,
+    LEGACY_ESCAPE_RE = /\bticket-ref-ok\b/i,
+    __filename = fileURLToPath(import.meta.url);
+
+/** @summary Exact numeric hashes carrying the typed CSS-color escape on the same token. */
+function escapedColorOffsets(comment) {
+    const offsets = new Set();
+
+    CSS_COLOR_ESCAPE_RE.lastIndex = 0;
+    for (const match of comment.matchAll(CSS_COLOR_ESCAPE_RE)) {
+        if (CSS_COLOR_CONTEXT_RE.test(comment.slice(Math.max(0, match.index - 48), match.index))) {
+            offsets.add(match.index)
+        }
+    }
+
+    return offsets
+}
+
+/** @summary Every typed false-positive marker, valid or not, on one comment row. */
+function typedEscapeMarkers(comment) {
+    ANY_TYPED_ESCAPE_RE.lastIndex = 0;
+
+    return [...comment.matchAll(ANY_TYPED_ESCAPE_RE)]
+}
+
+/** @summary JavaScript comments and JSDoc parsed from syntax rather than inferred punctuation. */
+function extractJavaScriptComments(content) {
+    const rows = [];
+
+    parse(content, {
+        allowHashBang: true,
+        ecmaVersion  : 'latest',
+        locations    : true,
+        sourceType   : 'module',
+        onComment(block, text, start, end, startLoc) {
+            text.split('\n').forEach((value, offset) => rows.push({line: startLoc.line + offset, text: value}))
+        }
+    });
+
+    return rows
+}
+
+/**
+ * @summary Finds decay-prone tracking or review anchors in comment and JSDoc context.
+ * @param {String} content
+ * @returns {{line: Number, text: String, kinds: String[]}[]}
+ */
+export function findArchaeology(content) {
+    const hits = [];
+
+    extractJavaScriptComments(content).forEach(row => {
+        const comment = row.text,
+              kinds   = new Set(),
+              escaped = escapedColorOffsets(comment),
+              markers = typedEscapeMarkers(comment);
+
+        if (!comment) return;
+
+        if (NAMED_TRACKING_PATTERNS.some(pattern => pattern.test(comment))) kinds.add('tracking-reference');
+        if (REVIEW_ARCHAEOLOGY_PATTERNS.some(pattern => pattern.test(comment))) kinds.add('review-archaeology');
+        if (LEGACY_ESCAPE_RE.test(comment) || markers.length !== escaped.size) kinds.add('invalid-escape');
+
+        NUMERIC_REF_RE.lastIndex = 0;
+        for (const match of comment.matchAll(NUMERIC_REF_RE)) {
+            if (!escaped.has(match.index)) kinds.add('tracking-reference')
+        }
+
+        if (kinds.size) hits.push({line: row.line, text: comment.trim(), kinds: [...kinds]})
+    });
+
+    return hits
+}
+
+/** @summary Whether a repository-relative path belongs to a generated or projected tree. */
+export function isIgnoredPath(file, ignores = DEFAULT_IGNORES) {
+    const parts = file.replaceAll('\\', '/').replace(/^\.\//, '').split('/');
+
+    return ignores.some(ignore => parts.includes(ignore))
+}
+
+/** @summary Whether a repository-relative path is a durable JavaScript module in scan scope. */
+export function isInScopePath(file, ignores = DEFAULT_IGNORES) {
+    return file.endsWith('.mjs') && !isIgnoredPath(file, ignores)
+}
+
+/** @summary Writes the bounded CLI usage contract. */
+function printHelp(write) {
+    write([
+        'Usage: neo-agent-skills-check-ticket-archaeology [options] [files...]',
+        '',
+        'Options:',
+        '  -b, --base <ref>     Scan changed tracked .mjs files against a merge base.',
+        '  -i, --ignore <list>  Comma-separated ignored path segments.',
+        '  -q, --quiet          Suppress individual violation lines.',
+        '  -h, --help           Show this help.'
+    ].join('\n'))
+}
+
+/** @summary Executes one Git read against the caller repository. */
+function git(args, cwd) {
+    return execFileSync('git', args, {cwd, encoding: 'utf8'})
+}
+
+/** @summary Normalizes one supplied path and refuses paths outside the caller repository. */
+function repoRelative(file, gitRoot) {
+    const normalized = isAbsolute(file) ? relative(gitRoot, file) : file;
+
+    if (normalized === '..' || normalized.startsWith('../')) {
+        throw new Error(`Path is outside the caller repository: ${file}`)
+    }
+
+    return normalized.replaceAll('\\', '/').replace(/^\.\//, '')
+}
+
+/**
+ * @summary Runs the portable archaeology gate against one caller repository.
+ * @param {String[]} argv
+ * @param {{cwd?: String, out?: Function, error?: Function}} options
+ * @returns {Number} Process exit code.
+ */
+export function run(argv = process.argv.slice(2), {cwd = process.cwd(), out = console.log, error = console.error} = {}) {
+    let parsed;
+
+    try {
+        parsed = parseArgs({
+            args            : argv,
+            allowPositionals: true,
+            strict          : true,
+            options         : {
+                base  : {type: 'string', short: 'b'},
+                help  : {type: 'boolean', short: 'h'},
+                ignore: {type: 'string', short: 'i', default: DEFAULT_IGNORES.join(',')},
+                quiet : {type: 'boolean', short: 'q', default: false}
+            }
+        })
+    } catch (cause) {
+        error(`check-ticket-archaeology: ${cause.message}`);
+        return 2
+    }
+
+    if (parsed.values.help) {
+        printHelp(out);
+        return 0
+    }
+
+    let gitRoot;
+
+    try {
+        gitRoot = git(['rev-parse', '--show-toplevel'], cwd).trim()
+    } catch {
+        error('check-ticket-archaeology: caller cwd is not inside a Git repository.');
+        return 2
+    }
+
+    const ignores = parsed.values.ignore.split(',').map(value => value.trim()).filter(Boolean);
+    let files, selection;
+
+    try {
+        if (parsed.values.base) {
+            files = git(['diff', '--name-only', '-z', '--diff-filter=ACMR', `${parsed.values.base}...HEAD`], gitRoot)
+                .split('\0').filter(Boolean);
+            selection = `changed vs ${parsed.values.base}`
+        } else if (parsed.positionals.length) {
+            files     = parsed.positionals.map(file => repoRelative(file, gitRoot));
+            selection = 'supplied paths'
+        } else {
+            files = git(['ls-files', '-z', '--', '*.mjs'], gitRoot).split('\0').filter(Boolean);
+            selection = 'all tracked .mjs files'
+        }
+    } catch (cause) {
+        error(`check-ticket-archaeology: file selection failed: ${cause.message}`);
+        return 2
+    }
+
+    files = [...new Set(files.map(file => repoRelative(file, gitRoot)).filter(file => isInScopePath(file, ignores)))].sort();
+
+    const failures = [],
+          unreadable = [],
+          unparsable = [],
+          realRoot   = realpathSync(gitRoot);
+
+    for (const file of files) {
+        let content;
+
+        try {
+            const full     = resolve(gitRoot, file),
+                  realFile = realpathSync(full),
+                  escaped  = relative(realRoot, realFile);
+
+            if (isAbsolute(escaped) || escaped === '..' || escaped.startsWith('../')) {
+                throw new Error('tracked path resolves outside the caller repository')
+            }
+
+            content = readFileSync(realFile, 'utf8')
+        } catch (cause) {
+            unreadable.push(`${file}: ${cause.message}`);
+            continue
+        }
+
+        try {
+            findArchaeology(content).forEach(hit => failures.push({file, ...hit}))
+        } catch (cause) {
+            unparsable.push(`${file}: ${cause.message}`)
+        }
+    }
+
+    if (unreadable.length) {
+        error(`check-ticket-archaeology: ${unreadable.length} selected file(s) could not be read (${selection}).`);
+        if (!parsed.values.quiet) unreadable.forEach(message => error(`  ${message}`));
+        return 2
+    }
+
+    if (unparsable.length) {
+        error(`check-ticket-archaeology: ${unparsable.length} selected module(s) could not be parsed (${selection}).`);
+        if (!parsed.values.quiet) unparsable.forEach(message => error(`  ${message}`));
+        return 2
+    }
+
+    if (failures.length) {
+        error(`check-ticket-archaeology: ${failures.length} decay-prone comment ref(s) across ${files.length} file(s) (${selection}).`);
+        if (!parsed.values.quiet) failures.forEach(hit => error(`  ${hit.file}:${hit.line}: ${hit.text}`));
+        error('Durable comments and JSDoc describe current behavior. Put tracking and review provenance in the PR or commit, not source comments.');
+        return 1
+    }
+
+    out(`check-ticket-archaeology: ${files.length} file(s), 0 violations (${selection}).`);
+    return 0
+}
+
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(__filename)) {
+    process.exitCode = run()
+}

--- a/scripts/check-ticket-archaeology.mjs
+++ b/scripts/check-ticket-archaeology.mjs
@@ -34,8 +34,8 @@ const
         /\b(?:earlier|previous|prior)\s+rounds?\b/i
     ]),
     NUMERIC_REF_RE = /#(\d+)(?![A-Za-z0-9_])/g,
-    CSS_COLOR_ESCAPE_RE = /#(\d{3}|\d{4}|\d{6}|\d{8})\s*\[not-ticket-ref:\s*css-color\]/gi,
-    CSS_COLOR_CONTEXT_RE = /(?:\bCSS\s+color\b|\b(?:background(?:-color)?|border(?:-color)?|color|fill|stroke)\s*(?::|=))\s*$/i,
+    CSS_COLOR_ESCAPE_RE = /#(\d{3}|\d{4}|\d{6}|\d{8})['"`]?\s*\[not-ticket-ref:\s*css-color\]/gi,
+    CSS_COLOR_CONTEXT_RE = /(?:\bCSS\s+color\b|\b(?:background(?:-?color)?|border(?:-?color)?|color|fill(?:style)?|stroke(?:style)?)_?\s*(?::|=)\s*['"`]?)\s*$/i,
     ANY_TYPED_ESCAPE_RE = /\[not-ticket-ref:[^\]]*\]/gi,
     LEGACY_ESCAPE_RE = /\bticket-ref-ok\b/i,
     __filename = fileURLToPath(import.meta.url);

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -3,9 +3,10 @@
  * @summary Mutation-sensitive contract checks for the reusable consumer PR baseline.
  *
  * GitHub validates YAML syntax when the branch is published; this suite protects the semantic
- * boundary that syntax cannot: one workflow-call entrypoint, read-only permissions, two stable
- * jobs, caller-repository checkout, the explicit dev-base decision, and the supported materializer
- * command. Each negative fixture removes one of those properties and must turn red.
+ * boundary that syntax cannot: one workflow-call entrypoint, read-only permissions, three stable
+ * jobs, caller-repository checkout, the explicit dev-base decision, immutable archaeology
+ * execution, and the supported materializer command. Each negative fixture removes one property
+ * and must turn red.
  *
  * Run: `node scripts/test-reusable-pr-baseline.mjs`
  */
@@ -17,7 +18,22 @@ import {fileURLToPath} from 'node:url';
 
 const
     here         = dirname(fileURLToPath(import.meta.url)),
-    workflowPath = join(here, '..', '.github', 'workflows', 'reusable-pr-baseline.yml');
+    root         = join(here, '..'),
+    workflowPath = join(root, '.github', 'workflows', 'reusable-pr-baseline.yml'),
+    pkg          = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
+
+/** @summary Isolates one top-level job so a sibling cannot satisfy its contract. */
+function jobSource(source, jobId) {
+    const marker = `  ${jobId}:\n`,
+          start  = source.indexOf(marker);
+
+    if (start === -1) return '';
+
+    const after = source.slice(start + marker.length),
+          next  = after.search(/^  [a-z0-9_-]+:\n/m);
+
+    return marker + (next === -1 ? after : after.slice(0, next))
+}
 
 /**
  * @summary Returns named semantic-contract violations in one reusable-workflow source string.
@@ -25,7 +41,10 @@ const
  * @returns {String[]}
  */
 export function validateReusablePrBaseline(source) {
-    const failures = [],
+    const failures       = [],
+          prBaseJob      = jobSource(source, 'pr-base'),
+          skillsJob      = jobSource(source, 'skills-materialized'),
+          archaeologyJob = jobSource(source, 'source-comment-archaeology'),
           required = [
               ['workflow-call trigger', /^on:\n  workflow_call:\n/m],
               ['read-only contents', /^permissions:\n  contents: read\n/m],
@@ -33,17 +52,20 @@ export function validateReusablePrBaseline(source) {
               ['PR-base stable name', /^    name: PR base\n/m],
               ['Skills job id', /^  skills-materialized:\n/m],
               ['Skills stable name', /^    name: Skills materialized\n/m],
+              ['archaeology job id', /^  source-comment-archaeology:\n/m],
+              ['archaeology stable name', /^    name: Source comment archaeology\n/m],
               ['required_base default', /^      required_base:\n[\s\S]*?^        default: dev\n/m],
-              ['non-PR refusal', /github\.event_name != 'pull_request'/],
-              ['base mismatch refusal', /github\.event\.pull_request\.base\.ref != inputs\.required_base/],
-              ['caller checkout', /uses: actions\/checkout@v4/],
+              ['PR-base non-PR refusal', /github\.event_name != 'pull_request'/, prBaseJob],
+              ['base mismatch refusal', /github\.event\.pull_request\.base\.ref != inputs\.required_base/, prBaseJob],
+              ['caller checkout', /uses: actions\/checkout@v4/, skillsJob],
               ['Node input', /node-version: \$\{\{ inputs\.node_version \}\}/],
-              ['lockfile install', /run: npm ci/],
-              ['materializer check', /run: npx --no-install neo-agent-skills-materialize --check/]
+              ['lockfile install', /run: npm ci/, skillsJob],
+              ['materializer check', /run: npx --no-install neo-agent-skills-materialize --check/, skillsJob],
+              ['archaeology non-PR refusal', /github\.event_name != 'pull_request'/, archaeologyJob]
           ];
 
-    required.forEach(([label, pattern]) => {
-        if (!pattern.test(source)) failures.push(`missing ${label}`)
+    required.forEach(([label, pattern, target = source]) => {
+        if (!pattern.test(target)) failures.push(`missing ${label}`)
     });
 
     const triggerBlock = source.match(/^on:\n([\s\S]*?)\njobs:/m)?.[1] || '';
@@ -52,6 +74,29 @@ export function validateReusablePrBaseline(source) {
         failures.push('direct event trigger present')
     }
     if (/^\s+repository:/m.test(source)) failures.push('checkout repository override present');
+    if (!/ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/.test(archaeologyJob)) {
+        failures.push('missing exact caller head')
+    }
+    if (!/fetch-depth: 0/.test(archaeologyJob)) failures.push('missing full history');
+    if ((archaeologyJob.match(/BASE_SHA: \$\{\{ github\.event\.pull_request\.base\.sha \}\}/g) || []).length !== 2) {
+        failures.push('missing exact base SHA')
+    }
+    if (!/git fetch --no-tags origin "\$\{BASE_SHA\}"/.test(archaeologyJob)) {
+        failures.push('missing exact base fetch')
+    }
+    if (!archaeologyJob.includes(`SKILLS_VERSION: '${pkg.version}'`)) failures.push('package version drift');
+    if ((archaeologyJob.match(/SKILLS_ROOT: \$\{\{ runner\.temp \}\}\/neo-agent-skills-source-comment-archaeology/g) || []).length !== 2) {
+        failures.push('missing isolated runner root')
+    }
+    if (!/npm install --prefix "\$\{SKILLS_ROOT\}" --ignore-scripts --package-lock=false --no-save/.test(archaeologyJob)) {
+        failures.push('missing isolated exact install')
+    }
+    if (!/"neo-agent-skills@\$\{SKILLS_VERSION\}"/.test(archaeologyJob)) failures.push('missing exact package spec');
+    if (!/"\$\{SKILLS_ROOT\}\/node_modules\/\.bin\/neo-agent-skills-ticket-archaeology"/.test(archaeologyJob)) {
+        failures.push('missing isolated absolute bin')
+    }
+    if (!/--base "\$\{BASE_SHA\}"/.test(archaeologyJob)) failures.push('missing exact base invocation');
+    if (/continue-on-error:\s*true/.test(source)) failures.push('continue-on-error present');
     if (/^\s+[a-z_-]+: write(?:-all)?\s*$/m.test(source) ||
         /^permissions: (?:read|write)-all\s*$/m.test(source)) {
         failures.push('write permission present')
@@ -86,8 +131,8 @@ expectMutationFailure('base job', source,
     value => value.replace('  pr-base:', '  removed-base:'),
     'missing PR-base job id');
 expectMutationFailure('base decision', source,
-    value => value.replace("github.event_name != 'pull_request'", 'false'),
-    'missing non-PR refusal');
+    value => value.replace("github.event_name != 'pull_request' || github.event.pull_request.base.ref != inputs.required_base", 'false'),
+    'missing PR-base non-PR refusal');
 expectMutationFailure('Skills job', source,
     value => value.replace('  skills-materialized:', '  removed-skills:'),
     'missing Skills job id');
@@ -97,5 +142,41 @@ expectMutationFailure('caller checkout', source,
 expectMutationFailure('materializer command', source,
     value => value.replace('neo-agent-skills-materialize --check', 'neo-agent-skills-materialize'),
     'missing materializer check');
+expectMutationFailure('exact caller head', source,
+    value => value.replace('ref: ${{ github.event.pull_request.head.sha }}', 'ref: dev'),
+    'missing exact caller head');
+expectMutationFailure('archaeology non-PR refusal', source,
+    value => value.replace("if: ${{ github.event_name != 'pull_request' }}", 'if: false'),
+    'missing archaeology non-PR refusal');
+expectMutationFailure('full history', source,
+    value => value.replace('fetch-depth: 0', 'fetch-depth: 1'),
+    'missing full history');
+expectMutationFailure('base fetch', source,
+    value => value.replace('git fetch --no-tags origin "${BASE_SHA}"', 'git fetch origin dev'),
+    'missing exact base fetch');
+expectMutationFailure('base SHA', source,
+    value => value.replace('BASE_SHA: ${{ github.event.pull_request.base.sha }}', 'BASE_SHA: dev'),
+    'missing exact base SHA');
+expectMutationFailure('base invocation', source,
+    value => value.replace('--base "${BASE_SHA}"', '--base origin/dev'),
+    'missing exact base invocation');
+expectMutationFailure('package version', source,
+    value => value.replace(`SKILLS_VERSION: '${pkg.version}'`, "SKILLS_VERSION: 'latest'"),
+    'package version drift');
+expectMutationFailure('runner isolation', source,
+    value => value.replace('${{ runner.temp }}/neo-agent-skills-source-comment-archaeology', '${{ github.workspace }}/guard'),
+    'missing isolated runner root');
+expectMutationFailure('isolated install', source,
+    value => value.replace('npm install --prefix "${SKILLS_ROOT}"', 'npm install'),
+    'missing isolated exact install');
+expectMutationFailure('exact package spec', source,
+    value => value.replace('"neo-agent-skills@${SKILLS_VERSION}"', '"neo-agent-skills@latest"'),
+    'missing exact package spec');
+expectMutationFailure('absolute bin', source,
+    value => value.replace('"${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-ticket-archaeology"', 'npx neo-agent-skills-ticket-archaeology'),
+    'missing isolated absolute bin');
+expectMutationFailure('continue on error', source,
+    value => value.replace('    runs-on: ubuntu-latest\n    steps:', '    runs-on: ubuntu-latest\n    continue-on-error: true\n    steps:'),
+    'continue-on-error present');
 
-console.log('reusable-pr-baseline: canonical contract + 8 negative mutations passed');
+console.log('reusable-pr-baseline: canonical contract + 20 negative mutations passed');

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -22,6 +22,8 @@ const
     workflowPath = join(root, '.github', 'workflows', 'reusable-pr-baseline.yml'),
     pkg          = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
 
+let mutationCount = 0;
+
 /** @summary Isolates one top-level job so a sibling cannot satisfy its contract. */
 function jobSource(source, jobId) {
     const marker = `  ${jobId}:\n`,
@@ -111,7 +113,8 @@ function expectMutationFailure(label, source, mutate, expectedFailure) {
           failures = validateReusablePrBaseline(mutated);
 
     assert.notEqual(mutated, source, `${label}: fixture mutation changed nothing`);
-    assert.ok(failures.includes(expectedFailure), `${label}: expected "${expectedFailure}", got ${failures.join(', ')}`)
+    assert.ok(failures.includes(expectedFailure), `${label}: expected "${expectedFailure}", got ${failures.join(', ')}`);
+    mutationCount++
 }
 
 const source = readFileSync(workflowPath, 'utf8');
@@ -179,4 +182,4 @@ expectMutationFailure('continue on error', source,
     value => value.replace('    runs-on: ubuntu-latest\n    steps:', '    runs-on: ubuntu-latest\n    continue-on-error: true\n    steps:'),
     'continue-on-error present');
 
-console.log('reusable-pr-baseline: canonical contract + 20 negative mutations passed');
+console.log(`reusable-pr-baseline: canonical contract + ${mutationCount} negative mutations passed`);

--- a/scripts/test-ticket-archaeology.mjs
+++ b/scripts/test-ticket-archaeology.mjs
@@ -1,0 +1,223 @@
+#!/usr/bin/env node
+/** @summary Mutation-sensitive contract checks for the portable ticket-archaeology CLI. */
+
+import assert                           from 'node:assert/strict';
+import {execFileSync, spawnSync}        from 'node:child_process';
+import {mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
+import {tmpdir}                         from 'node:os';
+import {dirname, join}                  from 'node:path';
+import {fileURLToPath}                  from 'node:url';
+import {findArchaeology, isInScopePath} from './check-ticket-archaeology.mjs';
+
+const
+    here  = dirname(fileURLToPath(import.meta.url)),
+    GUARD = join(here, 'check-ticket-archaeology.mjs'),
+    CLI_GUARD = GUARD.startsWith('/private/tmp/') ? GUARD.replace('/private/tmp/', '/tmp/') : GUARD;
+
+/** @summary Finding line numbers for one JavaScript source fixture. */
+function hitLines(source) {
+    return findArchaeology(source).map(hit => hit.line)
+}
+
+assert.deepEqual(hitLines([
+    '// smallest repo-local ref #1',
+    '// short repo-local ref #14',
+    '// three-digit repo-local ref #242',
+    '/** large repo-local ref #12345 */'
+].join('\n')), [1, 2, 3, 4]);
+
+assert.deepEqual(hitLines([
+    'const value = 1; // trailing ticket #14',
+    '/*',
+    ' * block ticket #242',
+    ' */'
+].join('\n')), [1, 3]);
+
+assert.deepEqual(hitLines([
+    '// issue 4 introduced it',
+    '// Ticket #18 owns it',
+    '// PR 242 reviewed it',
+    '// Epic #14 groups it',
+    '// Discussion 7 explored it',
+    '// ADR-3 settled it'
+].join('\n')), [1, 2, 3, 4, 5, 6]);
+
+assert.deepEqual(hitLines([
+    '// RA-1 added this arm',
+    '// review round 2 changed it',
+    '// round 3 reviewer disposition',
+    '// round 1 and round 2 both stayed green',
+    '// both earlier rounds were silent',
+    '// the first review cycle missed it'
+].join('\n')), [1, 2, 3, 4, 5, 6]);
+
+assert.deepEqual(findArchaeology([
+    '// Round 1: register the first window.',
+    '// Round 2: repeat with the opposite order.'
+].join('\n')), [], 'behavioral rounds are not review archaeology without a history marker');
+
+assert.deepEqual(findArchaeology([
+    "const title = 'ticket #14';",
+    "const url = 'https://github.com/neomjs/neo-agent-skills/issues/18';",
+    'const template = `review round 2 and #242`;',
+    "test('review witness (#242 RA-1)', () => {});",
+    '// theme token #1234ff'
+].join('\n')), []);
+
+assert.deepEqual(hitLines('// CSS color #000000 [not-ticket-ref: css-color]'), [],
+    'a typed marker exempts exactly one ambiguous numeric CSS token');
+assert.deepEqual(hitLines('// ticket #14 beside CSS color #000000 [not-ticket-ref: css-color]'), [1],
+    'the typed color marker cannot hide another tracking reference');
+assert.deepEqual(hitLines('// see #242 [not-ticket-ref: css-color]'), [1],
+    'a typed marker without CSS syntax cannot relabel a short ticket');
+assert.deepEqual(hitLines('// [not-ticket-ref: css-color]'), [1], 'an unused marker fails closed');
+assert.deepEqual(hitLines('// token #242'), [1], 'generic token wording cannot make a short ticket green');
+assert.deepEqual(hitLines('// theme #242'), [1], 'generic theme wording cannot make a short ticket green');
+
+assert.deepEqual(hitLines('// ref #14 ticket-ref-ok: implementation history'), [1],
+    'a legacy escape marker must not suppress a real tracking reference');
+assert.deepEqual(hitLines('// ticket-ref-ok: stale escape'), [1], 'a legacy marker is itself invalid');
+assert.deepEqual(hitLines("const marker = 'ticket-ref-ok'; // ticket #14"), [1],
+    'a code string cannot suppress a trailing comment');
+
+assert.deepEqual(findArchaeology([
+    'const raw = `line one',
+    '// ticket #14 is template data',
+    'line three`;'
+].join('\n')), [], 'comment punctuation in template data remains a string');
+
+assert.deepEqual(hitLines([
+    'const template = `value ${(() => {',
+    '    // nested ticket #14',
+    '    return 1',
+    '})()}`;'
+].join('\n')), [2], 'real comments inside template expressions remain visible');
+
+assert.throws(() => findArchaeology('export const = broken;'), /Unexpected token/,
+    'invalid modules fail closed instead of looking comment-clean');
+
+assert.equal(isInScopePath('src/Foo.mjs'), true);
+assert.equal(isInScopePath('apps/demo/Main.mjs'), true);
+assert.equal(isInScopePath('.claude/hooks/stop.mjs'), true);
+assert.equal(isInScopePath('resources/source.mjs'), true);
+assert.equal(isInScopePath('node_modules/pkg/index.mjs'), false);
+assert.equal(isInScopePath('src/Foo.js'), false);
+
+const repo    = mkdtempSync(join(tmpdir(), 'skills-archaeology-')),
+      outside = mkdtempSync(join(tmpdir(), 'skills-archaeology-outside-'));
+
+try {
+    const git = args => execFileSync('git', args, {cwd: repo, encoding: 'utf8'});
+
+    git(['init', '-b', 'dev']);
+    git(['config', 'user.name', 'Contract Test']);
+    git(['config', 'user.email', 'contract@example.invalid']);
+
+    writeFileSync(join(repo, 'existing.mjs'), '// old archaeology #14\nexport const value = 1;\n');
+    git(['add', 'existing.mjs']);
+    git(['commit', '-m', 'baseline']);
+    const base = git(['rev-parse', 'HEAD']).trim();
+
+    writeFileSync(join(repo, 'existing.mjs'), '// old archaeology #14\nexport const value = 2;\n');
+    writeFileSync(join(repo, 'clean.mjs'), 'export const clean = true;\n');
+    git(['add', 'existing.mjs', 'clean.mjs']);
+    git(['commit', '-m', 'change']);
+
+    assert.doesNotMatch(git(['diff', '--unified=0', base, 'HEAD', '--', 'existing.mjs']), /^\+.*#14/m,
+        'the whole-file red control must predate the changed lines');
+
+    const run = args => spawnSync(process.execPath, [CLI_GUARD, ...args], {cwd: repo, encoding: 'utf8'});
+    const changed = run(['--base', base]);
+
+    assert.equal(changed.status, 1);
+    assert.match(changed.stderr, /existing\.mjs:1/);
+    assert.doesNotMatch(changed.stderr, /clean\.mjs:/);
+
+    const supplied = run(['existing.mjs']);
+    assert.equal(supplied.status, 1);
+
+    const allTracked = run([]);
+    assert.equal(allTracked.status, 1);
+
+    writeFileSync(join(repo, 'existing.mjs'), '// current behavior\nexport const value = 2;\n');
+    git(['add', 'existing.mjs']);
+    git(['commit', '-m', 'clean']);
+
+    const clean = run(['--base', 'HEAD~1']);
+    assert.equal(clean.status, 0, clean.stderr);
+    assert.match(clean.stdout, /0 violations/);
+
+    writeFileSync(join(repo, 'untracked.mjs'), '// untracked archaeology #14\n');
+
+    const trackedOnly = run([]);
+    assert.equal(trackedOnly.status, 0, trackedOnly.stderr);
+
+    const invalid = run(['--unknown']);
+    assert.equal(invalid.status, 2);
+    assert.match(invalid.stderr, /Unknown option/);
+
+    writeFileSync(join(outside, 'target.mjs'), '// current behavior\n');
+    symlinkSync(join(outside, 'target.mjs'), join(repo, 'escape.mjs'));
+    git(['add', 'escape.mjs']);
+    git(['commit', '-m', 'escape']);
+
+    const escaped = run(['escape.mjs']);
+    assert.equal(escaped.status, 2);
+    assert.match(escaped.stderr, /outside the caller repository/)
+} finally {
+    rmSync(repo, {recursive: true, force: true});
+    rmSync(outside, {recursive: true, force: true})
+}
+
+const distribution = mkdtempSync(join(tmpdir(), 'skills-archaeology-pack-'));
+
+try {
+    const root     = join(here, '..'),
+          packDir  = join(distribution, 'pack'),
+          cacheDir = join(distribution, 'npm-cache'),
+          consumer = join(distribution, 'consumer');
+
+    mkdirSync(packDir, {recursive: true});
+    mkdirSync(consumer, {recursive: true});
+
+    const npmEnv = {...process.env, npm_config_cache: cacheDir},
+          packed = JSON.parse(execFileSync('npm', ['pack', '--pack-destination', packDir, '--json'], {
+              cwd: root, encoding: 'utf8', env: npmEnv
+          })),
+          tarball = join(packDir, packed[0].filename);
+
+    writeFileSync(join(consumer, 'package.json'), JSON.stringify({name: 'guard-consumer', private: true}, null, 2));
+    execFileSync('npm', [
+        'install', '--ignore-scripts', '--package-lock=false', '--no-save', tarball
+    ], {cwd: consumer, encoding: 'utf8', env: npmEnv});
+
+    const git = args => execFileSync('git', args, {cwd: consumer, encoding: 'utf8'}),
+          bin = join(consumer, 'node_modules', '.bin', 'neo-agent-skills-ticket-archaeology');
+
+    git(['init', '-b', 'dev']);
+    git(['config', 'user.name', 'Packed Contract']);
+    git(['config', 'user.email', 'packed@example.invalid']);
+    writeFileSync(join(consumer, 'probe.mjs'), 'export const value = 1;\n');
+    git(['add', 'probe.mjs']);
+    git(['commit', '-m', 'baseline']);
+    const base = git(['rev-parse', 'HEAD']).trim();
+
+    writeFileSync(join(consumer, 'probe.mjs'), '// review RA-1\nexport const value = 2;\n');
+    git(['add', 'probe.mjs']);
+    git(['commit', '-m', 'red']);
+
+    const red = spawnSync(bin, ['--base', base], {cwd: consumer, encoding: 'utf8'});
+    assert.equal(red.status, 1);
+    assert.match(red.stderr, /review-archaeology|decay-prone/);
+
+    writeFileSync(join(consumer, 'probe.mjs'), '// current behavior\nexport const value = 3;\n');
+    git(['add', 'probe.mjs']);
+    git(['commit', '-m', 'green']);
+
+    const green = spawnSync(bin, ['--base', 'HEAD~1'], {cwd: consumer, encoding: 'utf8'});
+    assert.equal(green.status, 0, green.stderr)
+} finally {
+    rmSync(distribution, {recursive: true, force: true})
+}
+
+console.log('ticket-archaeology: repository-local ids, controls, CLI modes, and packed bin passed');

--- a/scripts/test-ticket-archaeology.mjs
+++ b/scripts/test-ticket-archaeology.mjs
@@ -66,10 +66,18 @@ assert.deepEqual(findArchaeology([
 
 assert.deepEqual(hitLines('// CSS color #000000 [not-ticket-ref: css-color]'), [],
     'a typed marker exempts exactly one ambiguous numeric CSS token');
+assert.deepEqual(hitLines("// @member {String} backgroundColor_='#000000' [not-ticket-ref: css-color]"), [],
+    'the typed marker relieves the camelCase property idiom that motivated the Engine bug');
+assert.deepEqual(hitLines('// borderColor="#111111" [not-ticket-ref: css-color]'), [],
+    'a quoted camelCase color assignment is explicit color context');
+assert.deepEqual(hitLines('// fillStyle=`#123456` [not-ticket-ref: css-color]'), [],
+    'canvas-style color properties use the same typed escape');
 assert.deepEqual(hitLines('// ticket #14 beside CSS color #000000 [not-ticket-ref: css-color]'), [1],
     'the typed color marker cannot hide another tracking reference');
 assert.deepEqual(hitLines('// see #242 [not-ticket-ref: css-color]'), [1],
     'a typed marker without CSS syntax cannot relabel a short ticket');
+assert.deepEqual(hitLines("// issue='#9473' [not-ticket-ref: css-color]"), [1],
+    'generic quoted assignments cannot launder a real reference');
 assert.deepEqual(hitLines('// [not-ticket-ref: css-color]'), [1], 'an unused marker fails closed');
 assert.deepEqual(hitLines('// token #242'), [1], 'generic token wording cannot make a short ticket green');
 assert.deepEqual(hitLines('// theme #242'), [1], 'generic theme wording cannot make a short ticket green');


### PR DESCRIPTION
Resolves #18

Related: #14

Publishes one Skills-owned source-comment guard and adds it as the third stable job in the existing reusable PR baseline. The job checks the caller's exact head against the event's exact base SHA while installing an exact Skills release outside the caller workspace, so a pull request cannot weaken the guard through its own lockfile or local binary.

Evidence: L3 (packed binary installed and executed against red/green repositories; exact Brain source probe caught the short-ID and review-history violations) → L3 required (portable source and reusable enforcement contract). Residual: package publication and consumer-pin rollout, Residual-Owner: #14.

## AC Evidence

| AC | Evidence |
|---|---|
| AC-1 | `scripts/test-ticket-archaeology.mjs` commits archaeology in the baseline, changes only another line, and proves the whole touched file still fails. |
| AC-2 | The detector fixtures cover 1-, 2-, 3-, and 5-digit hashes plus named issue, ticket, PR, Epic, Discussion, ADR, and review-cycle forms. |
| AC-3 | Acorn-backed fixtures preserve ordinary strings, URLs, template data, and a token-scoped numeric CSS-color control. |
| AC-4 | Legacy `ticket-ref-ok`, code-string suppression, unused or misapplied typed markers, and mixed real-ref/color lines all remain red. |
| AC-5 | Line, trailing, block, JSDoc, template-expression, pre-existing whole-file, parse-failure, symlink-escape, and CLI-mode controls execute in the focused suite. |
| AC-6 | `.github/workflows/reusable-pr-baseline.yml` exposes least-privilege job `source-comment-archaeology` with stable name `Source comment archaeology`. |
| AC-7 | `scripts/test-reusable-pr-baseline.mjs` carries 20 negative mutations covering exact head/base SHAs, fetch, package version/spec, runner isolation, absolute bin, permissions, and failure propagation; the packed bin executes the real guard. |
| AC-8 | `package.json` publishes `neo-agent-skills-ticket-archaeology`; `package-lock.json` pins Acorn; the tarball install test invokes the installed `.bin`. |
| AC-9 | The diff is confined to `neo-agent-skills`; no consumer repository is edited. |
| AC-10 | Parent #14 remains the explicit owner of post-release caller adoption; this source leaf creates no speculative consumer files or tickets. |

## Deltas from ticket

- Extended the already-published reusable PR baseline instead of introducing a second reusable workflow.
- Replaced the Engine hand lexer with Acorn comment tokens and fail-closed parsing; direct porting would preserve the measured short-ID and template-expression false greens.
- The reusable job installs the exact package release in `${{ runner.temp }}` rather than trusting caller-controlled dependencies.
- YAML comment lint remains outside this `.mjs` leaf: block-scalar and multiline-value falsifiers proved that a casual line scanner would be another false-green/false-red mechanism.

## Test Evidence

- `node scripts/test-ticket-archaeology.mjs` — repository-local IDs, parser controls, full-file selection, escaping symlink refusal, and packed-bin red/green execution passed.
- `node scripts/test-reusable-pr-baseline.mjs` — canonical contract plus 20 negative mutations passed.
- `node scripts/lint-skill-corpus.mjs` — 37 skills coherent, within budget, canonical document reach.
- Exact Brain head `5a9f9961d9242a457e71cd0bdb479c75663c2ba8` — the new detector found the remaining `#239`, `RA-1`, `round 1/round 2 stayed green`, and `earlier rounds` comment archaeology that the four-digit guard misses.
- `npm pack --dry-run --json` — the CLI ships executable; source tests and workflows do not enter the tarball.

## Post-Merge Validation

- [ ] After the next package publish, verify the registry's exact `0.1.2` release exposes `neo-agent-skills-ticket-archaeology` before parent #14 advances consumer pins.

Authored by Euclid (OpenAI GPT-5.6 Sol, Codex Desktop). Session 6243a442-7ced-4c0f-81c6-99b0f8358e63.
