### PR TITLE
feat(ci): share the substrate byte-budget guard as a baseline job (#25)

### DIFF
--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -93,3 +93,42 @@ jobs:
         run: >-
           "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-ticket-archaeology"
           --base "${BASE_SHA}"
+
+  substrate-size:
+    name: Substrate size
+    runs-on: ubuntu-latest
+    steps:
+      - name: Reject a non-PR caller
+        if: ${{ github.event_name != 'pull_request' }}
+        run: exit 1
+
+      # The head tree is the whole input: this guard measures what a seat loads at this commit and
+      # compares nothing against the base, so it needs no history.
+      - name: Checkout exact caller head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      # The guard runs from runner.temp, never from the caller workspace. A checked-out copy would
+      # be the same diff under review, so a pull request could widen the limit it is judged by, or
+      # drop an entry from the target roster, and pass its own gate. The limit ships with the
+      # pinned release; nothing on the command line can move it.
+      - name: Install immutable substrate guard
+        env:
+          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size
+          SKILLS_VERSION: '0.1.2'
+        run: >-
+          npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
+          "neo-agent-skills@${SKILLS_VERSION}"
+
+      # Invoked bare, against the checked-out caller tree. A repository carrying none of the
+      # substrate entry points reports N/A and greens: three of the five consumers have no such
+      # files, and a baseline they cannot adopt is not a baseline.
+      - name: Measure the per-turn substrate budget
+        env:
+          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size
+        run: "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-substrate-size"

--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -125,10 +125,18 @@ jobs:
           npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
           "neo-agent-skills@${SKILLS_VERSION}"
 
-      # Invoked bare, against the checked-out caller tree. A repository carrying none of the
-      # substrate entry points reports N/A and greens: three of the five consumers have no such
-      # files, and a baseline they cannot adopt is not a baseline.
+      # Measured against the checked-out caller tree. A repository carrying none of the substrate
+      # entry points reports N/A and greens: three of the five consumers have no such files, and a
+      # baseline they cannot adopt is not a baseline.
+      #
+      # `working-directory` is PINNED to the workflow-owned `github.workspace` and is load-bearing,
+      # not tidiness. The guard resolves its root from cwd, and every target is ENOENT outside the
+      # checkout — so a bare invocation from any other directory reports all-N/A and GREENS. Under
+      # the negative-space contract a wrong root is indistinguishable from a legitimately empty
+      # consumer, which makes the pin the only thing separating "nothing to measure" from "measured
+      # nothing". Found by @neo-gpt in review; asserted by the workflow-contract suite.
       - name: Measure the per-turn substrate budget
+        working-directory: ${{ github.workspace }}
         env:
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size
         run: "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-substrate-size"

--- a/.github/workflows/skill-corpus.yml
+++ b/.github/workflows/skill-corpus.yml
@@ -52,6 +52,9 @@ jobs:
       - name: Ticket archaeology contract and packed CLI
         run: node scripts/test-ticket-archaeology.mjs
 
+      - name: Substrate budget contract and packed CLI
+        run: node scripts/test-substrate-size.mjs
+
       - name: Package contents — what actually ships
         run: |
           TARBALL=$(npm pack --silent | tail -1)
@@ -64,8 +67,13 @@ jobs:
             || { echo "materializer missing from the tarball"; exit 1; }
           tar tzf "$TARBALL" | grep -q 'package/scripts/check-ticket-archaeology.mjs' \
             || { echo "ticket-archaeology CLI missing from the tarball"; exit 1; }
+          # The substrate guard is only a gate if it SHIPS: the baseline job installs the pinned
+          # release and runs it from there, so a CLI absent from the tarball is a job that installs
+          # cleanly and then cannot invoke anything.
+          tar tzf "$TARBALL" | grep -q 'package/scripts/check-substrate-size.mjs' \
+            || { echo "substrate-size CLI missing from the tarball"; exit 1; }
 
-          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs' 'package/scripts/test-ticket-archaeology.mjs'; do
+          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs' 'package/scripts/test-ticket-archaeology.mjs' 'package/scripts/test-substrate-size.mjs'; do
             tar tzf "$TARBALL" | grep -q "$unwanted" \
               && { echo "$unwanted ships to consumers and should not"; exit 1; }
           done

--- a/README.md
+++ b/README.md
@@ -67,6 +67,36 @@ repositories call the stable `Source comment archaeology` job in
 its exact guard release outside the caller workspace, so a pull request cannot weaken its own gate by
 changing the caller lockfile or local binary.
 
+## Shared substrate byte-budget guard
+
+```bash
+npx --no-install neo-agent-skills-substrate-size
+```
+
+Measures what a seat actually **loads** per turn — `AGENTS.md`, `.agents/ANTIGRAVITY_RULES.md`,
+`.claude/CLAUDE.md` — against a **24,576-byte** per-file limit, and fails the check on a breach.
+
+Loaded bytes, not file bytes: symlinks resolve through `realpathSync` (an `lstat` on a symlinked
+`CLAUDE.md` reports **12** — the length of `../AGENTS.md`), and whole-line `@path` imports are summed
+recursively as one unit with a cycle guard keyed on file identity. It reports **headroom** rather than
+pass/fail, because this drift is gradual: by the time a file flips to EXCEEDS it is already truncating.
+
+**Past the limit the harness silently truncates the BOTTOM of the file**, so a seat loses the tail of
+its own rules with nothing reporting it — the one failure that cannot be observed from inside the seat
+suffering it.
+
+**A missing entry point is `not applicable`, never a failure.** Consumers legitimately differ: only
+some carry all three. **Only `ENOENT` means absent** — a permission denial or an unreadable path is an
+error and fails the check, because absent is a claim about the repository while unreadable is a claim
+about the observation, and a failed observation supports neither.
+
+Consumer repositories call the stable `Substrate size` job in
+`.github/workflows/reusable-pr-baseline.yml` through an immutable Skills revision. **The limit ships
+with the guard, not with the caller**: the job installs its exact release outside the caller workspace
+and pins the measurement to the checked-out tree, so a pull request cannot widen the limit it is judged
+by, drop an entry from the target roster, or move the measurement to a directory where every target is
+absent and the check greens on nothing.
+
 ## What is in the package
 
 | path | what |
@@ -74,6 +104,7 @@ changing the caller lockfile or local binary.
 | `.agents/skills/` | the substrate — skills plus `skills.manifest.json` and its schema |
 | `scripts/materialize-harness-skills.mjs` | the postinstall linker and its `--check` arm |
 | `scripts/check-ticket-archaeology.mjs` | the portable comment/JSDoc archaeology guard |
+| `scripts/check-substrate-size.mjs` | the portable per-turn substrate byte-budget guard |
 
 The manifest governs **projection**: a skill declaring `claudeSymlinkRequired: false` is a declared
 opt-out and is correctly absent from the façade. Per-skill links rather than one directory link,

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
             },
             "bin": {
                 "neo-agent-skills-materialize": "scripts/materialize-harness-skills.mjs",
+                "neo-agent-skills-substrate-size": "scripts/check-substrate-size.mjs",
                 "neo-agent-skills-ticket-archaeology": "scripts/check-ticket-archaeology.mjs"
             },
             "engines": {

--- a/package.json
+++ b/package.json
@@ -19,8 +19,9 @@
         "acorn": "^8.18.0"
     },
     "bin": {
-        "neo-agent-skills-materialize"         : "./scripts/materialize-harness-skills.mjs",
-        "neo-agent-skills-ticket-archaeology" : "./scripts/check-ticket-archaeology.mjs"
+        "neo-agent-skills-materialize"        : "./scripts/materialize-harness-skills.mjs",
+        "neo-agent-skills-substrate-size"    : "./scripts/check-substrate-size.mjs",
+        "neo-agent-skills-ticket-archaeology": "./scripts/check-ticket-archaeology.mjs"
     },
     "exports": {
         "./manifest"    : "./.agents/skills/skills.manifest.json",
@@ -29,13 +30,14 @@
     "files": [
         ".agents/skills",
         "scripts/materialize-harness-skills.mjs",
+        "scripts/check-substrate-size.mjs",
         "scripts/check-ticket-archaeology.mjs",
         "README.md"
     ],
     "scripts": {
         "materialize": "node scripts/materialize-harness-skills.mjs",
         "lint"       : "node scripts/lint-skill-corpus.mjs",
-        "test"       : "node scripts/test-lint-skill-corpus.mjs && node scripts/test-reusable-pr-baseline.mjs && node scripts/test-ticket-archaeology.mjs"
+        "test"       : "node scripts/test-lint-skill-corpus.mjs && node scripts/test-reusable-pr-baseline.mjs && node scripts/test-ticket-archaeology.mjs && node scripts/test-substrate-size.mjs"
     },
     "keywords": [
         "neo.mjs",

--- a/scripts/check-substrate-size.mjs
+++ b/scripts/check-substrate-size.mjs
@@ -1,0 +1,301 @@
+#!/usr/bin/env node
+/**
+ * @summary Enforces the per-turn agent substrate byte budget in a consuming repository.
+ *
+ * Past the limit a harness silently truncates the BOTTOM of the file, so a seat loses the tail of
+ * its own rules with nothing reporting it. The failure cannot be observed from inside the seat that
+ * suffers it, which is why it needs a gate rather than a habit.
+ *
+ * The command runs against a caller tree, not against this package checkout. The limit and the
+ * target roster ship WITH the guard, so a pull request cannot widen the budget it is measured by:
+ * neither is a command-line option, and the reusable baseline installs a pinned release outside the
+ * caller workspace before invoking it.
+ */
+
+import {lstatSync, readFileSync, realpathSync}       from 'node:fs';
+import {dirname, isAbsolute, join, relative, resolve} from 'node:path';
+import process                                       from 'node:process';
+import {parseArgs}                                   from 'node:util';
+import {fileURLToPath}                               from 'node:url';
+
+/**
+ * Per-file budget, in bytes — Antigravity's documented per-file hard limit.
+ *
+ * Deliberately not a CLI option. A graduated budget is an architectural decision, and a limit a
+ * caller can pass is a limit a caller can raise in the same diff the guard is meant to judge. The
+ * remedy for a breach is Progressive Disclosure: move granular instruction into `.agents/skills/`.
+ *
+ * @member {Number} PER_FILE_LIMIT_BYTES
+ */
+export const PER_FILE_LIMIT_BYTES = 24576;
+
+/**
+ * The per-turn entry points, each naming the harness that loads it.
+ *
+ * The number's substrate is per-harness, and inheriting one harness's constant into another's
+ * contract is how correct-looking arithmetic governs the wrong seat. `24576` is Antigravity's
+ * documented limit. The Claude seat's own cap is an operator-stated constraint whose semantics —
+ * what it is measured over — remain unconfirmed, because the experiment that would settle them
+ * needs a fresh authenticated seat and has not run. Until it does, that row is checked against the
+ * inherited number and `limitConfirmed: false` says so out loud, so the next reader inherits a
+ * flagged assumption rather than a silent one.
+ *
+ * A repository that carries none of these is not in scope for the budget and is reported as such.
+ *
+ * @member {Object[]} TARGET_FILES
+ */
+export const TARGET_FILES = Object.freeze([
+    {path: 'AGENTS.md',                    harness: 'Antigravity + Claude', limitConfirmed: true},
+    {path: '.agents/ANTIGRAVITY_RULES.md', harness: 'Antigravity',          limitConfirmed: true},
+    {path: '.claude/CLAUDE.md',            harness: 'Claude Code',          limitConfirmed: false}
+]);
+
+/**
+ * A whole-line `@path` import. Claude Code resolves these relative to the importing file and loads
+ * the target's CONTENT, so the importer's own byte count is not what the seat pays.
+ *
+ * @member {RegExp} AT_IMPORT_PATTERN
+ */
+export const AT_IMPORT_PATTERN = /^@(\S+)\s*$/;
+
+/**
+ * @summary Returns the bytes a harness actually loads for an entry point, following BOTH indirections.
+ *
+ * An entry point can reach its content two ways, and the same file has been spelled both: a SYMLINK
+ * to a shared rules file, or a real file carrying `@`-imports. A check that reads only one form
+ * computes the wrong total — `lstat` on a symlink reports the length of the target PATH STRING (12
+ * bytes for `../AGENTS.md`), and an import stub reports its own ~25 bytes, while the seat loads tens
+ * of kilobytes in either case.
+ *
+ * Symlinks resolve through `realpathSync`, which also keys the cycle guard on file identity rather
+ * than on the path used to reach it. Imports recurse, because an imported file may import further.
+ *
+ * @param {String}      file Root-relative or absolute path to the entry point.
+ * @param {Object}      [options={}]
+ * @param {String}      [options.root=process.cwd()] Base for relative paths and for reported member names.
+ * @param {Set<String>} [options.seen] Realpaths already counted — cycle guard and double-count guard.
+ * @returns {{bytes: Number, members: String[]}} Loaded bytes, and the imported members contributing.
+ * @throws {Error} If an import names a file that does not exist. A budget that silently drops a
+ *   renamed member measures a fiction and passes, so this fails closed rather than skipping.
+ */
+export function resolveLoadedSize(file, {root = process.cwd(), seen = new Set()} = {}) {
+    const
+        full = isAbsolute(file) ? file : join(root, file),
+        real = realpathSync(full),
+        // Members are named relative to the CANONICAL root. Imports resolve against `real`, so a
+        // tree reached through a symlink — every macOS temp directory, and any checkout under a
+        // linked path — would otherwise name each member by a `../../..` climb out of the
+        // unresolved root and back down, which reads as a path escape rather than as composition.
+        base = realpathSync(root);
+
+    // An entry point reachable twice (symlink plus direct import) is paid for once by the loader.
+    if (seen.has(real)) {
+        return {bytes: 0, members: []}
+    }
+
+    seen.add(real);
+
+    const
+        text    = readFileSync(real, 'utf8'),
+        members = [];
+
+    let bytes = Buffer.byteLength(text, 'utf8');
+
+    text.split('\n').forEach(line => {
+        const match = line.match(AT_IMPORT_PATTERN);
+
+        if (!match) {
+            return
+        }
+
+        const target = resolve(dirname(real), match[1]);
+
+        let child;
+
+        try {
+            child = resolveLoadedSize(target, {root, seen})
+        } catch {
+            throw new Error(`${file} imports '${match[1]}', which cannot be read`)
+        }
+
+        bytes += child.bytes;
+        members.push(relative(base, target), ...child.members)
+    });
+
+    return {bytes, members}
+}
+
+/**
+ * @summary Measures every target and returns one row per entry point — the pure half of the guard.
+ *
+ * Returned rather than printed so the arms that matter can be asserted without spawning a process:
+ * a guard whose only observable is stdout gets tested by reading its own log line back, which
+ * confirms the formatter rather than the measurement.
+ *
+ * **Absent and unreadable are different verdicts, and conflating them is how this guard would fail
+ * open.** A repository carrying none of these files is not in breach of a budget it does not
+ * participate in, so an absent target is `applicable: false` and never fails. But `existsSync`
+ * FOLLOWS symlinks, so a dangling entry point would answer "absent" and be skipped — the guard would
+ * go quiet on a seat whose rules resolve to nothing. Presence is therefore decided by `lstat`, which
+ * sees the entry itself: present-but-unresolvable is an error, not a skip.
+ *
+ * @param {Object}   [options={}]
+ * @param {String}   [options.root=process.cwd()] Tree to measure.
+ * @param {Object[]} [options.targets=TARGET_FILES]
+ * @param {Number}   [options.limit=PER_FILE_LIMIT_BYTES] Test seam only; no caller passes this.
+ * @returns {Object[]} Rows: `{file, harness, limitConfirmed, applicable, bytes, members, over, headroom, error}`.
+ */
+export function collectReport({root = process.cwd(), targets = TARGET_FILES, limit = PER_FILE_LIMIT_BYTES} = {}) {
+    return targets.map(({path: file, harness, limitConfirmed}) => {
+        const row = {
+            file, harness, limitConfirmed,
+            applicable: true, bytes: null, members: [], over: false, headroom: null, error: null
+        };
+
+        try {
+            lstatSync(join(root, file))
+        } catch {
+            row.applicable = false;
+            return row
+        }
+
+        let loaded;
+
+        try {
+            loaded = resolveLoadedSize(file, {root})
+        } catch (cause) {
+            // Fail closed: an unresolvable member means the total is unknown, and an unknown total
+            // must never render as a pass.
+            row.error = cause.message;
+            return row
+        }
+
+        row.bytes    = loaded.bytes;
+        row.members  = loaded.members;
+        row.over     = loaded.bytes > limit;
+        row.headroom = limit - loaded.bytes;
+
+        return row
+    })
+}
+
+/** @summary Prints the CLI contract. */
+function printHelp(out) {
+    out([
+        'Usage: neo-agent-skills-substrate-size [--root <dir>] [--quiet]',
+        '',
+        'Measures the per-turn agent substrate entry points in a consuming repository against the',
+        `${PER_FILE_LIMIT_BYTES} byte per-file budget, following symlinks and whole-line @-imports.`,
+        '',
+        '  --root, -r   Tree to measure. Defaults to the current working directory.',
+        '  --quiet, -q  Print only the verdict line.',
+        '  --help,  -h  Print this help.',
+        '',
+        'Exit codes: 0 measured and within budget (or no targets present), 1 breach or unmeasurable',
+        'target, 2 CLI misuse. The limit and the target roster are not options — they ship with the',
+        'guard so a pull request cannot widen the budget it is judged by.'
+    ].join('\n'))
+}
+
+/**
+ * @summary Reports every target and returns the process exit code.
+ * @param {String[]} argv
+ * @param {{cwd?: String, out?: Function, error?: Function}} options
+ * @returns {Number} Process exit code.
+ */
+export function run(argv = process.argv.slice(2), {cwd = process.cwd(), out = console.log, error = console.error} = {}) {
+    let parsed;
+
+    try {
+        parsed = parseArgs({
+            args            : argv,
+            allowPositionals: false,
+            strict          : true,
+            options         : {
+                help : {type: 'boolean', short: 'h', default: false},
+                quiet: {type: 'boolean', short: 'q', default: false},
+                root : {type: 'string',  short: 'r'}
+            }
+        })
+    } catch (cause) {
+        error(`check-substrate-size: ${cause.message}`);
+        return 2
+    }
+
+    if (parsed.values.help) {
+        printHelp(out);
+        return 0
+    }
+
+    const
+        root  = resolve(cwd, parsed.values.root ?? '.'),
+        quiet = parsed.values.quiet,
+        rows  = collectReport({root});
+
+    rows.forEach(({file, harness, limitConfirmed, applicable, bytes, members, over, headroom, error: rowError}) => {
+        if (quiet) {
+            return
+        }
+
+        if (!applicable) {
+            out(`➖ ${file.padEnd(30)} : not present — N/A for this repository`);
+            return
+        }
+
+        if (rowError) {
+            error(`❌ ${file.padEnd(30)} : ${rowError}`);
+            return
+        }
+
+        // Headroom, not just pass/fail: this drift is gradual, so a shrinking margin is the signal.
+        // By the time it flips to a breach the substrate is already truncating, and headroom counts
+        // the bytes an author may still ADD, which is the question they are actually asking.
+        out(`${over ? '❌' : '✅'} ${file.padEnd(30)} : ${bytes} bytes · limit ${PER_FILE_LIMIT_BYTES} · ` +
+            `${over ? `OVER by ${-headroom}` : `headroom ${headroom}`} · ${harness}` +
+            `${limitConfirmed ? '' : ' · limit inherited from another harness, semantics unconfirmed'}`);
+
+        // Name what the total is made of whenever it is more than the file itself, so a reader can
+        // see WHY an entry point costs more than its own bytes rather than re-deriving the chain.
+        members.length && out(`   composed via @-import: ${members.join(', ')}`)
+    });
+
+    const
+        breached     = rows.filter(row => row.over),
+        unmeasurable = rows.filter(row => row.error),
+        measured     = rows.filter(row => row.applicable && !row.error);
+
+    if (breached.length || unmeasurable.length) {
+        breached.forEach(row => error(
+            `check-substrate-size: ${row.file} is ${row.bytes} bytes, over the ${PER_FILE_LIMIT_BYTES} byte limit by ${-row.headroom}.`
+        ));
+        unmeasurable.forEach(row => error(`check-substrate-size: ${row.file} could not be measured — ${row.error}`));
+        error('The bottom of an over-budget file is silently truncated and a seat loses the tail of its own rules.');
+        error('Fix by migrating granular instruction into .agents/skills/ (Progressive Disclosure).');
+        error('Do NOT raise the limit to make this pass: a graduated budget is a decision, not a lint setting.');
+        return 1
+    }
+
+    if (!measured.length) {
+        out(`check-substrate-size: no substrate entry points in this repository — N/A, nothing to measure.`);
+        return 0
+    }
+
+    out(`check-substrate-size: ${measured.length} of ${rows.length} entry point(s) present, all within ${PER_FILE_LIMIT_BYTES} bytes.`);
+    return 0
+}
+
+// Entrypoint guard, canonicalized on BOTH sides — and it has to be both.
+//
+// The common spellings compare `process.argv[1]` to `import.meta.url` directly, which disagree
+// whenever the script is reached through a symlink: argv[1] is the link path, import.meta.url is the
+// resolved target, so the module loads, `run()` never runs, and the process exits 0 — a guard that
+// silently stops guarding, in a script whose entire job is to fail loudly. A package `bin` IS such a
+// symlink once installed, so this is the shipping path, not an edge case.
+//
+// Realpathing only argv[1] fixes the ordinary symlink case and leaves one open, because
+// import.meta.url is usually already resolved but not always: under `--preserve-symlinks-main` node
+// keeps the link path there, so the resolved argv[1] and the unresolved import.meta.url differ and
+// the guard goes false again. Same silent exit 0, reachable by a flag rather than by a link.
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))) {
+    process.exitCode = run()
+}

--- a/scripts/check-substrate-size.mjs
+++ b/scripts/check-substrate-size.mjs
@@ -154,8 +154,23 @@ export function collectReport({root = process.cwd(), targets = TARGET_FILES, lim
 
         try {
             lstatSync(join(root, file))
-        } catch {
-            row.applicable = false;
+        } catch (cause) {
+            // ENOENT ONLY. A bare catch made "not applicable" absorb every filesystem failure — a
+            // permission denial, an unreadable mount, a malformed root whose parent component is not
+            // a directory — and each of those exited 0 as a legitimately empty consumer. That is the
+            // fail-open shape this guard exists to prevent, reintroduced by the very negative-space
+            // contract that lets Brain, Skills and Institution adopt the baseline at all.
+            //
+            // Absent is a claim about the repository. Unreadable is a claim about the observation,
+            // and an observation that failed supports neither verdict. Found by @neo-gpt in review.
+            if (cause.code === 'ENOENT') {
+                row.applicable = false;
+                return row
+            }
+
+            row.error = `${file}: cannot observe the entry (${cause.code || 'unknown'}) — refusing ` +
+                `to score an unreadable target as absent. ${cause.message}`;
+
             return row
         }
 

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -3,10 +3,10 @@
  * @summary Mutation-sensitive contract checks for the reusable consumer PR baseline.
  *
  * GitHub validates YAML syntax when the branch is published; this suite protects the semantic
- * boundary that syntax cannot: one workflow-call entrypoint, read-only permissions, three stable
- * jobs, caller-repository checkout, the explicit dev-base decision, immutable archaeology
- * execution, and the supported materializer command. Each negative fixture removes one property
- * and must turn red.
+ * boundary that syntax cannot: one workflow-call entrypoint, read-only permissions, four stable
+ * jobs, caller-repository checkout, the explicit dev-base decision, immutable archaeology and
+ * substrate-budget execution, and the supported materializer command. Each negative fixture removes
+ * one property and must turn red.
  *
  * Run: `node scripts/test-reusable-pr-baseline.mjs`
  */
@@ -47,6 +47,7 @@ export function validateReusablePrBaseline(source) {
           prBaseJob      = jobSource(source, 'pr-base'),
           skillsJob      = jobSource(source, 'skills-materialized'),
           archaeologyJob = jobSource(source, 'source-comment-archaeology'),
+          substrateJob   = jobSource(source, 'substrate-size'),
           required = [
               ['workflow-call trigger', /^on:\n  workflow_call:\n/m],
               ['read-only contents', /^permissions:\n  contents: read\n/m],
@@ -63,7 +64,16 @@ export function validateReusablePrBaseline(source) {
               ['Node input', /node-version: \$\{\{ inputs\.node_version \}\}/],
               ['lockfile install', /run: npm ci/, skillsJob],
               ['materializer check', /run: npx --no-install neo-agent-skills-materialize --check/, skillsJob],
-              ['archaeology non-PR refusal', /github\.event_name != 'pull_request'/, archaeologyJob]
+              ['archaeology non-PR refusal', /github\.event_name != 'pull_request'/, archaeologyJob],
+              ['substrate job id', /^  substrate-size:\n/m],
+              ['substrate stable name', /^    name: Substrate size\n/m],
+              ['substrate non-PR refusal', /github\.event_name != 'pull_request'/, substrateJob],
+              ['substrate caller head', /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/, substrateJob],
+              ['substrate isolated exact install',
+                  /npm install --prefix "\$\{SKILLS_ROOT\}" --ignore-scripts --package-lock=false --no-save/, substrateJob],
+              ['substrate exact package spec', /"neo-agent-skills@\$\{SKILLS_VERSION\}"/, substrateJob],
+              ['substrate isolated absolute bin',
+                  /"\$\{SKILLS_ROOT\}\/node_modules\/\.bin\/neo-agent-skills-substrate-size"/, substrateJob]
           ];
 
     required.forEach(([label, pattern, target = source]) => {
@@ -98,6 +108,19 @@ export function validateReusablePrBaseline(source) {
         failures.push('missing isolated absolute bin')
     }
     if (!/--base "\$\{BASE_SHA\}"/.test(archaeologyJob)) failures.push('missing exact base invocation');
+    if (!substrateJob.includes(`SKILLS_VERSION: '${pkg.version}'`)) failures.push('substrate package version drift');
+    if ((substrateJob.match(/SKILLS_ROOT: \$\{\{ runner\.temp \}\}\/neo-agent-skills-substrate-size/g) || []).length !== 2) {
+        failures.push('missing substrate isolated runner root')
+    }
+
+    // The guard is invoked bare. Every argument it accepts narrows what gets measured, so a steered
+    // invocation in a shared baseline is the same hole as running the caller's own copy: the tree
+    // under review decides how hard it is judged. The limit is not an option at all; --root would
+    // point the measurement somewhere other than the caller head.
+    if (/neo-agent-skills-substrate-size"[^\n]*\S/.test(substrateJob)) {
+        failures.push('substrate guard invoked with arguments')
+    }
+
     if (/continue-on-error:\s*true/.test(source)) failures.push('continue-on-error present');
     if (/^\s+[a-z_-]+: write(?:-all)?\s*$/m.test(source) ||
         /^permissions: (?:read|write)-all\s*$/m.test(source)) {
@@ -178,6 +201,45 @@ expectMutationFailure('exact package spec', source,
 expectMutationFailure('absolute bin', source,
     value => value.replace('"${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-ticket-archaeology"', 'npx neo-agent-skills-ticket-archaeology'),
     'missing isolated absolute bin');
+expectMutationFailure('substrate job', source,
+    value => value.replace('  substrate-size:', '  removed-substrate:'),
+    'missing substrate job id');
+expectMutationFailure('substrate stable name', source,
+    value => value.replace('    name: Substrate size', '    name: Substrate budget'),
+    'missing substrate stable name');
+expectMutationFailure('substrate non-PR refusal', source,
+    value => value.replace(
+        "      - name: Reject a non-PR caller\n        if: ${{ github.event_name != 'pull_request' }}\n        run: exit 1\n\n      # The head tree",
+        '      # The head tree'),
+    'missing substrate non-PR refusal');
+expectMutationFailure('substrate caller head', source,
+    value => value.replace(
+        '        with:\n          ref: ${{ github.event.pull_request.head.sha }}\n\n      - uses: actions/setup-node@v4\n        with:\n          node-version: ${{ inputs.node_version }}\n\n      # The guard runs from runner.temp',
+        '\n      - uses: actions/setup-node@v4\n        with:\n          node-version: ${{ inputs.node_version }}\n\n      # The guard runs from runner.temp'),
+    'missing substrate caller head');
+expectMutationFailure('substrate runner isolation', source,
+    value => value.replace(/\$\{\{ runner\.temp \}\}\/neo-agent-skills-substrate-size/g, '${{ github.workspace }}/guard'),
+    'missing substrate isolated runner root');
+expectMutationFailure('substrate package version', source,
+    value => value.replace(
+        "          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size\n          SKILLS_VERSION: '0.1.2'",
+        "          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size\n          SKILLS_VERSION: 'latest'"),
+    'substrate package version drift');
+expectMutationFailure('substrate isolated install', source,
+    value => value.replace(
+        '          npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save\n          "neo-agent-skills@${SKILLS_VERSION}"\n\n      # Invoked bare',
+        '          npm install "neo-agent-skills@${SKILLS_VERSION}"\n\n      # Invoked bare'),
+    'missing substrate isolated exact install');
+expectMutationFailure('substrate absolute bin', source,
+    value => value.replace(
+        'run: "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-substrate-size"',
+        'run: npx neo-agent-skills-substrate-size'),
+    'missing substrate isolated absolute bin');
+expectMutationFailure('substrate steered invocation', source,
+    value => value.replace(
+        'run: "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-substrate-size"',
+        'run: "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-substrate-size" --root docs'),
+    'substrate guard invoked with arguments');
 expectMutationFailure('continue on error', source,
     value => value.replace('    runs-on: ubuntu-latest\n    steps:', '    runs-on: ubuntu-latest\n    continue-on-error: true\n    steps:'),
     'continue-on-error present');

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -68,7 +68,7 @@ export function validateReusablePrBaseline(source) {
               ['substrate job id', /^  substrate-size:\n/m],
               ['substrate stable name', /^    name: Substrate size\n/m],
               ['substrate non-PR refusal', /github\.event_name != 'pull_request'/, substrateJob],
-              ['substrate caller head', /ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/, substrateJob],
+              ['substrate caller head', /^\s*ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}\s*$/m, substrateJob],
               ['substrate isolated exact install',
                   /npm install --prefix "\$\{SKILLS_ROOT\}" --ignore-scripts --package-lock=false --no-save/, substrateJob],
               ['substrate exact package spec', /"neo-agent-skills@\$\{SKILLS_VERSION\}"/, substrateJob],
@@ -78,8 +78,14 @@ export function validateReusablePrBaseline(source) {
               // The guard resolves its root from cwd; outside the checkout every target is ENOENT,
               // which the negative-space contract reports as N/A — so a bare invocation from any
               // other directory GREENS. Asserted here because it is a silent failure everywhere else.
+              //
+              // ANCHORED TO END-OF-LINE, and that is the whole point of the assertion. The first
+              // version matched the pin as an unanchored substring, so `${{ github.workspace }}/docs`
+              // satisfied it — a wrong root passing the contract that exists to forbid wrong roots
+              // (RA-2, PR #26). A suffix on a PATH value silently redirects; substring presence can
+              // never express "and nothing follows".
               ['substrate measurement pinned to the caller workspace',
-                  /working-directory: \$\{\{ github\.workspace \}\}/, substrateJob]
+                  /^\s*working-directory: \$\{\{ github\.workspace \}\}\s*$/m, substrateJob]
           ];
 
     required.forEach(([label, pattern, target = source]) => {
@@ -92,7 +98,7 @@ export function validateReusablePrBaseline(source) {
         failures.push('direct event trigger present')
     }
     if (/^\s+repository:/m.test(source)) failures.push('checkout repository override present');
-    if (!/ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/.test(archaeologyJob)) {
+    if (!/^\s*ref: \$\{\{ github\.event\.pull_request\.head\.sha \}\}\s*$/m.test(archaeologyJob)) {
         failures.push('missing exact caller head')
     }
     if (!/fetch-depth: 0/.test(archaeologyJob)) failures.push('missing full history');
@@ -103,7 +109,9 @@ export function validateReusablePrBaseline(source) {
         failures.push('missing exact base fetch')
     }
     if (!archaeologyJob.includes(`SKILLS_VERSION: '${pkg.version}'`)) failures.push('package version drift');
-    if ((archaeologyJob.match(/SKILLS_ROOT: \$\{\{ runner\.temp \}\}\/neo-agent-skills-source-comment-archaeology/g) || []).length !== 2) {
+    // Anchored for the same reason as the workspace pin: `…-source-comment-archaeology-x` is a
+    // DIFFERENT install root that an unanchored match accepts.
+    if ((archaeologyJob.match(/^\s*SKILLS_ROOT: \$\{\{ runner\.temp \}\}\/neo-agent-skills-source-comment-archaeology\s*$/gm) || []).length !== 2) {
         failures.push('missing isolated runner root')
     }
     if (!/npm install --prefix "\$\{SKILLS_ROOT\}" --ignore-scripts --package-lock=false --no-save/.test(archaeologyJob)) {
@@ -115,7 +123,7 @@ export function validateReusablePrBaseline(source) {
     }
     if (!/--base "\$\{BASE_SHA\}"/.test(archaeologyJob)) failures.push('missing exact base invocation');
     if (!substrateJob.includes(`SKILLS_VERSION: '${pkg.version}'`)) failures.push('substrate package version drift');
-    if ((substrateJob.match(/SKILLS_ROOT: \$\{\{ runner\.temp \}\}\/neo-agent-skills-substrate-size/g) || []).length !== 2) {
+    if ((substrateJob.match(/^\s*SKILLS_ROOT: \$\{\{ runner\.temp \}\}\/neo-agent-skills-substrate-size\s*$/gm) || []).length !== 2) {
         failures.push('missing substrate isolated runner root')
     }
 
@@ -251,6 +259,33 @@ expectMutationFailure('substrate steered invocation', source,
         'run: "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-substrate-size"',
         'run: "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-substrate-size" --root docs'),
     'substrate guard invoked with arguments');
+// ── RA-2: any root OTHER than the caller workspace must red ────────────────────────────────────
+//
+// The three below are one defect class, not three bugs. Each asserts a PATH, and each was written
+// as an unanchored substring — so appending a suffix produced a DIFFERENT root that satisfied the
+// contract forbidding different roots. A wrong `working-directory` is the dangerous one: the guard
+// resolves its targets from cwd, so outside the checkout every target is ENOENT, the negative-space
+// contract reports N/A, and the job GREENS having measured nothing.
+//
+// A suffix mutation is the only shape that catches this. Replacing the value wholesale (the shape
+// every other mutation here uses) reds against an unanchored pattern too, so it cannot distinguish
+// an anchored assertion from an unanchored one — it would have passed before this fix and after it.
+expectMutationFailure('substrate workspace pin — suffixed root', source,
+    value => value.replace(
+        'working-directory: ${{ github.workspace }}',
+        'working-directory: ${{ github.workspace }}/docs'),
+    'missing substrate measurement pinned to the caller workspace');
+expectMutationFailure('substrate runner root — suffixed root', source,
+    value => value.replace(
+        'SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size',
+        'SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size-shadow'),
+    'missing substrate isolated runner root');
+expectMutationFailure('archaeology runner root — suffixed root', source,
+    value => value.replace(
+        'SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology',
+        'SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology-shadow'),
+    'missing isolated runner root');
+
 expectMutationFailure('continue on error', source,
     value => value.replace('    runs-on: ubuntu-latest\n    steps:', '    runs-on: ubuntu-latest\n    continue-on-error: true\n    steps:'),
     'continue-on-error present');

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -73,7 +73,13 @@ export function validateReusablePrBaseline(source) {
                   /npm install --prefix "\$\{SKILLS_ROOT\}" --ignore-scripts --package-lock=false --no-save/, substrateJob],
               ['substrate exact package spec', /"neo-agent-skills@\$\{SKILLS_VERSION\}"/, substrateJob],
               ['substrate isolated absolute bin',
-                  /"\$\{SKILLS_ROOT\}\/node_modules\/\.bin\/neo-agent-skills-substrate-size"/, substrateJob]
+                  /"\$\{SKILLS_ROOT\}\/node_modules\/\.bin\/neo-agent-skills-substrate-size"/, substrateJob],
+              // The pin is the only thing separating "nothing to measure" from "measured nothing".
+              // The guard resolves its root from cwd; outside the checkout every target is ENOENT,
+              // which the negative-space contract reports as N/A — so a bare invocation from any
+              // other directory GREENS. Asserted here because it is a silent failure everywhere else.
+              ['substrate measurement pinned to the caller workspace',
+                  /working-directory: \$\{\{ github\.workspace \}\}/, substrateJob]
           ];
 
     required.forEach(([label, pattern, target = source]) => {
@@ -225,10 +231,15 @@ expectMutationFailure('substrate package version', source,
         "          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size\n          SKILLS_VERSION: '0.1.2'",
         "          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size\n          SKILLS_VERSION: 'latest'"),
     'substrate package version drift');
+// Anchored on the STEP NAME rather than the comment that follows it. The archaeology job carries a
+// byte-identical install line, so this fixture needs something after it to disambiguate — it used
+// the prose `# Invoked bare`, and editing that comment silently turned the mutation into a no-op,
+// which `expectMutationFailure` then reported as a broken fixture rather than a passing contract.
+// A negative fixture coupled to prose fails the moment prose is correct-but-different.
 expectMutationFailure('substrate isolated install', source,
     value => value.replace(
-        '          npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save\n          "neo-agent-skills@${SKILLS_VERSION}"\n\n      # Invoked bare',
-        '          npm install "neo-agent-skills@${SKILLS_VERSION}"\n\n      # Invoked bare'),
+        /(      - name: Install immutable substrate guard\n[\s\S]*?)          npm install --prefix "\$\{SKILLS_ROOT\}" --ignore-scripts --package-lock=false --no-save\n          "neo-agent-skills@\$\{SKILLS_VERSION\}"/,
+        '$1          npm install "neo-agent-skills@${SKILLS_VERSION}"'),
     'missing substrate isolated exact install');
 expectMutationFailure('substrate absolute bin', source,
     value => value.replace(

--- a/scripts/test-substrate-size.mjs
+++ b/scripts/test-substrate-size.mjs
@@ -1,0 +1,297 @@
+#!/usr/bin/env node
+/** @summary Mutation-sensitive contract checks for the portable substrate-size CLI. */
+
+import assert                                                        from 'node:assert/strict';
+import {spawnSync}                                                   from 'node:child_process';
+import {mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
+import {tmpdir}                                                      from 'node:os';
+import {dirname, join}                                               from 'node:path';
+import {fileURLToPath}                                               from 'node:url';
+import {PER_FILE_LIMIT_BYTES, collectReport, resolveLoadedSize, run} from './check-substrate-size.mjs';
+
+const
+    here      = dirname(fileURLToPath(import.meta.url)),
+    GUARD     = join(here, 'check-substrate-size.mjs'),
+    // macOS resolves /tmp through a symlink, and one arm below asserts what node does with symlinked
+    // entrypoints. Spawning the already-resolved path would decide that arm before it runs.
+    CLI_GUARD = GUARD.startsWith('/private/tmp/') ? GUARD.replace('/private/tmp/', '/tmp/') : GUARD,
+    fixtures  = [];
+
+/** @summary A disposable tree, cleaned up when the file finishes. */
+function fixture() {
+    const root = mkdtempSync(join(tmpdir(), 'substrate-size-'));
+
+    fixtures.push(root);
+    return root
+}
+
+/** @summary Writes a file, creating its directory. */
+function write(root, file, body) {
+    mkdirSync(dirname(join(root, file)), {recursive: true});
+    writeFileSync(join(root, file), body);
+    return join(root, file)
+}
+
+/** @summary Collects a run's stdout/stderr without printing it. */
+function capture(argv, cwd) {
+    const lines = [];
+
+    return {code: run(argv, {cwd, out: line => lines.push(line), error: line => lines.push(line)}), text: lines.join('\n')}
+}
+
+// ── A repository with no substrate files greens the job ────────────────────────────────────────
+// The Engine implementation this ports errored on an absent target, which would red the Brain,
+// Skills and Institution for correctly carrying none. A baseline three of five consumers cannot
+// adopt is not a baseline, so absent is N/A and never a failure.
+{
+    const root = fixture(),
+          rows = collectReport({root});
+
+    assert.equal(rows.length, 3);
+    assert.ok(rows.every(row => row.applicable === false), 'every absent target is reported not-applicable');
+    assert.ok(rows.every(row => row.error === null), 'an absent target is never an error');
+
+    const {code, text} = capture([], root);
+
+    assert.equal(code, 0, 'a repository with zero targets exits 0');
+    assert.match(text, /N\/A/, 'and says N/A rather than passing silently');
+}
+
+// ── A partially-populated repository measures what is there ────────────────────────────────────
+{
+    const root = fixture();
+
+    write(root, 'AGENTS.md', 'a'.repeat(100));
+
+    const rows = collectReport({root});
+
+    assert.equal(rows.find(row => row.file === 'AGENTS.md').bytes, 100);
+    assert.equal(rows.find(row => row.file === 'AGENTS.md').headroom, PER_FILE_LIMIT_BYTES - 100);
+    assert.equal(rows.filter(row => !row.applicable).length, 2, 'the two absent targets stay N/A');
+    assert.equal(capture([], root).code, 0);
+}
+
+// ── A breach exits non-zero and names the file, its bytes and the limit ────────────────────────
+{
+    const root = fixture(),
+          size = PER_FILE_LIMIT_BYTES + 1;
+
+    write(root, 'AGENTS.md', 'a'.repeat(size));
+
+    const {code, text} = capture([], root);
+
+    assert.equal(code, 1);
+    assert.match(text, /AGENTS\.md/);
+    assert.match(text, new RegExp(String(size)), 'the failure names the measured byte count');
+    assert.match(text, new RegExp(String(PER_FILE_LIMIT_BYTES)), 'and the limit it breached');
+    assert.match(text, /OVER by 1/, 'and by how much');
+}
+
+// ── Exactly at the limit passes; one byte past it fails ────────────────────────────────────────
+// The comparison is `>`, and a `>=` mutation would red a file that fits exactly. Asserting only the
+// breach case cannot see that: both spellings fail an over-limit file.
+{
+    const root = fixture();
+
+    write(root, 'AGENTS.md', 'a'.repeat(PER_FILE_LIMIT_BYTES));
+    assert.equal(capture([], root).code, 0, 'a file exactly at the limit is not a breach');
+
+    write(root, 'AGENTS.md', 'a'.repeat(PER_FILE_LIMIT_BYTES + 1));
+    assert.equal(capture([], root).code, 1);
+}
+
+// ── A symlinked entry point is measured as its resolution, not as the link ─────────────────────
+// This is the surface that hid: `lstat` on a symlink reports the length of the target PATH STRING —
+// 12 bytes for `../AGENTS.md` — while the seat reads the whole file through it. An lstat-only
+// implementation reports 12 here and passes a tree that is 5 bytes over budget.
+{
+    const root  = fixture(),
+          bytes = PER_FILE_LIMIT_BYTES + 5;
+
+    write(root, 'AGENTS.md', 'a'.repeat(bytes));
+    mkdirSync(join(root, '.claude'), {recursive: true});
+    symlinkSync('../AGENTS.md', join(root, '.claude/CLAUDE.md'));
+
+    const row = collectReport({root}).find(entry => entry.file === '.claude/CLAUDE.md');
+
+    assert.equal(row.applicable, true, 'a symlinked target is present');
+    assert.equal(row.bytes, bytes, 'the link is measured as what it resolves to');
+    assert.notEqual(row.bytes, '../AGENTS.md'.length, 'and not as the length of the target path string');
+    assert.equal(row.over, true);
+    assert.equal(capture([], root).code, 1);
+}
+
+// ── A dangling entry point is an error, never a skip ───────────────────────────────────────────
+// `existsSync` follows symlinks, so the obvious presence test answers "absent" for a link pointing
+// at nothing — and with absent now meaning N/A, the guard would go quiet on a seat whose rules
+// resolve to no bytes at all. Presence is decided by `lstat`, which sees the entry itself.
+{
+    const root = fixture();
+
+    mkdirSync(join(root, '.claude'), {recursive: true});
+    symlinkSync('../AGENTS.md', join(root, '.claude/CLAUDE.md'));
+
+    const row = collectReport({root}).find(entry => entry.file === '.claude/CLAUDE.md');
+
+    assert.equal(row.applicable, true, 'a dangling link is present, not absent');
+    assert.ok(row.error, 'and unmeasurable, which fails closed');
+
+    const {code, text} = capture([], root);
+
+    assert.equal(code, 1, 'a target that exists and cannot be measured is a failure');
+    assert.match(text, /could not be measured/);
+}
+
+// ── Whole-line @-imports are summed as one loaded unit ─────────────────────────────────────────
+{
+    const root = fixture();
+
+    write(root, 'rules/extra.md', 'b'.repeat(500));
+    write(root, '.claude/CLAUDE.md', ['# seat', '@../rules/extra.md', ''].join('\n'));
+
+    const
+        stub = readFileSync(join(root, '.claude/CLAUDE.md')).length,
+        row  = collectReport({root}).find(entry => entry.file === '.claude/CLAUDE.md');
+
+    assert.equal(row.bytes, stub + 500, 'the seat pays for the importer plus everything it pulls in');
+    assert.deepEqual(row.members, ['rules/extra.md'], 'and the composition is named');
+}
+
+// ── Members are named against the canonical root, even when the root is reached by a link ──────
+// Imports resolve against the importer's realpath. Naming members relative to an UNRESOLVED root
+// produces a `../../..` climb out of the tree and back down — it reads as a path escape rather than
+// as composition. macOS reaches every temp directory through a symlink, so the arm above sees this
+// locally; Linux CI does not, and would green a regression. This arm links the root explicitly.
+{
+    const
+        real = fixture(),
+        link = join(fixture(), 'linked-root');
+
+    write(real, 'rules/extra.md', 'b'.repeat(500));
+    write(real, '.claude/CLAUDE.md', '@../rules/extra.md\n');
+    symlinkSync(real, link);
+
+    assert.deepEqual(
+        collectReport({root: link}).find(entry => entry.file === '.claude/CLAUDE.md').members,
+        ['rules/extra.md']
+    )
+}
+
+// ── An import is only an import on its own line ────────────────────────────────────────────────
+// A pattern without anchors would count prose mentioning an @path as a load, inflating every total.
+{
+    const root = fixture();
+
+    write(root, 'rules/extra.md', 'b'.repeat(500));
+    write(root, '.claude/CLAUDE.md', 'see @../rules/extra.md for detail\n');
+
+    assert.equal(collectReport({root}).find(entry => entry.file === '.claude/CLAUDE.md').members.length, 0)
+}
+
+// ── Imports recurse, and a cycle terminates instead of hanging ─────────────────────────────────
+{
+    const root = fixture();
+
+    write(root, 'a.md', '@b.md\n');
+    write(root, 'b.md', '@a.md\n');
+
+    const {bytes, members} = resolveLoadedSize('a.md', {root});
+
+    assert.equal(bytes, '@b.md\n'.length + '@a.md\n'.length, 'each member is paid for once');
+    assert.deepEqual(members, ['b.md', 'a.md'])
+}
+
+// ── The cycle guard keys on file IDENTITY, not on the path used to reach it ────────────────────
+// Two paths to one file is the normal shape here: an entry point is a symlink, and something also
+// imports the target directly. Keying the guard on the path string counts those bytes twice and
+// reports a budget the seat never pays — inflated toward a false breach rather than a false pass,
+// but wrong either way.
+{
+    const root = fixture();
+
+    write(root, 'AGENTS.md', '@link.md\n');
+    symlinkSync(join(root, 'AGENTS.md'), join(root, 'link.md'));
+
+    assert.equal(resolveLoadedSize('AGENTS.md', {root}).bytes, '@link.md\n'.length,
+        'the same file reached by two names is paid for once')
+}
+
+// ── A missing import fails closed rather than dropping a member ────────────────────────────────
+// A budget that silently skips a renamed member measures a fiction and reports it as a pass.
+{
+    const root = fixture();
+
+    write(root, 'AGENTS.md', '@renamed.md\n');
+
+    const {code, text} = capture([], root);
+
+    assert.equal(code, 1);
+    assert.match(text, /renamed\.md/)
+}
+
+// ── The limit is not a command-line option ─────────────────────────────────────────────────────
+// The gate's whole value is that a pull request cannot widen the budget it is judged by. A `--limit`
+// flag would hand that back, and this arm reds if one is ever added.
+{
+    const root = fixture();
+
+    write(root, 'AGENTS.md', 'a'.repeat(PER_FILE_LIMIT_BYTES + 1));
+
+    const {code} = capture(['--limit', '999999'], root);
+
+    assert.equal(code, 2, 'an unknown option is CLI misuse, not a wider budget');
+    assert.equal(capture([], root).code, 1, 'and the breach still reds')
+}
+
+// ── Process-level arms: the shipping path, not just the exported functions ─────────────────────
+{
+    const root = fixture();
+
+    write(root, 'AGENTS.md', 'a'.repeat(PER_FILE_LIMIT_BYTES + 1));
+
+    const breach = spawnSync(process.execPath, [CLI_GUARD, '--root', root], {encoding: 'utf8'});
+
+    assert.equal(breach.status, 1, 'a breach exits 1 as a process, not only as a return value');
+    assert.match(breach.stderr, /over the 24576 byte limit/);
+
+    const clean = spawnSync(process.execPath, [CLI_GUARD, '--root', fixture()], {encoding: 'utf8'});
+
+    assert.equal(clean.status, 0, 'an empty tree exits 0 as a process');
+
+    const help = spawnSync(process.execPath, [CLI_GUARD, '--help'], {encoding: 'utf8'});
+
+    assert.equal(help.status, 0);
+    assert.match(help.stdout, /neo-agent-skills-substrate-size/)
+}
+
+// ── The entrypoint guard survives BOTH ways a path can arrive unresolved ───────────────────────
+// Reached through a symlink, argv[1] is the link and import.meta.url is the target; under
+// --preserve-symlinks-main it is the other way round. Either mismatch makes the guard false, and a
+// guard that never runs exits 0 with nothing measured — indistinguishable from a pass.
+{
+    const
+        root = fixture(),
+        link = join(fixture(), 'substrate-size-link.mjs');
+
+    write(root, 'AGENTS.md', 'a'.repeat(PER_FILE_LIMIT_BYTES + 1));
+    symlinkSync(GUARD, link);
+
+    const viaLink = spawnSync(process.execPath, [link, '--root', root], {encoding: 'utf8'});
+
+    assert.equal(viaLink.status, 1, 'invoked through a symlink — the installed `bin` shape — the guard still runs');
+
+    const preserved = spawnSync(process.execPath, ['--preserve-symlinks-main', link, '--root', root], {encoding: 'utf8'});
+
+    assert.equal(preserved.status, 1, 'and under --preserve-symlinks-main, which reverses which side is unresolved')
+}
+
+// ── The CLI ships with a bin entry, or consumers cannot invoke it ──────────────────────────────
+{
+    const pkg = JSON.parse(readFileSync(join(here, '../package.json'), 'utf8'));
+
+    assert.equal(pkg.bin['neo-agent-skills-substrate-size'], './scripts/check-substrate-size.mjs')
+}
+
+fixtures.forEach(root => rmSync(root, {recursive: true, force: true}));
+
+console.log('check-substrate-size: contract arms green.');

--- a/scripts/test-substrate-size.mjs
+++ b/scripts/test-substrate-size.mjs
@@ -3,7 +3,7 @@
 
 import assert                                                        from 'node:assert/strict';
 import {spawnSync}                                                   from 'node:child_process';
-import {mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
+import {chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync} from 'node:fs';
 import {tmpdir}                                                      from 'node:os';
 import {dirname, join}                                               from 'node:path';
 import {fileURLToPath}                                               from 'node:url';
@@ -283,6 +283,35 @@ function capture(argv, cwd) {
     const preserved = spawnSync(process.execPath, ['--preserve-symlinks-main', link, '--root', root], {encoding: 'utf8'});
 
     assert.equal(preserved.status, 1, 'and under --preserve-symlinks-main, which reverses which side is unresolved')
+}
+
+// ── An UNREADABLE target is an error, never "not applicable" ───────────────────────────────────
+//
+// The negative-space contract is what lets Brain, Skills and Institution adopt this baseline: a
+// repository carrying no substrate files is not in breach of a budget it does not participate in.
+// That contract also creates a new way to fail open, and the first implementation took it — a bare
+// `catch` around the presence probe absorbed EVERY filesystem error, so a permission denial, an
+// unreadable mount, or a malformed root reported "not applicable" and exited 0.
+//
+// Absent is a claim about the repository; unreadable is a claim about the observation, and a failed
+// observation supports neither. Only ENOENT may mean absent. Found by @neo-gpt in review.
+{
+    const root = fixture();
+
+    write(root, 'AGENTS.md', 'A'.repeat(100));
+    write(root, '.agents/ANTIGRAVITY_RULES.md', 'R'.repeat(100));
+    chmodSync(join(root, '.agents'), 0o000);
+
+    const rows    = collectReport({root}),
+          blocked = rows.find(row => row.file === '.agents/ANTIGRAVITY_RULES.md'),
+          {code}  = capture(['--root', root], root);
+
+    // Restored before asserting, so a failing assertion cannot leave an unremovable fixture behind.
+    chmodSync(join(root, '.agents'), 0o755);
+
+    assert.equal(blocked.applicable, true, 'an unreadable target must not be scored as absent');
+    assert.match(blocked.error, /EACCES/, 'the error must name the filesystem cause');
+    assert.equal(code, 1, 'an unreadable target must exit non-zero, not green as an empty consumer')
 }
 
 // ── The CLI ships with a bin entry, or consumers cannot invoke it ──────────────────────────────


### PR DESCRIPTION
Resolves #25

The substrate byte-budget guard now lives here once and runs for every consumer through `reusable-pr-baseline.yml`, replacing the Engine-local copy I built in `neomjs/neo` PR #17912 — the duplication Epic #14 exists to end. Two properties the Engine version lacked come with it: an absent target is **not applicable** rather than an error, so the three repositories that correctly carry no substrate files can adopt the baseline; and the limit ships with the pinned guard, so a caller cannot widen the budget it is judged by.

Evidence: **L3** (packed-tarball install invoked as a real process against every real consumer tree, plus a tampered-caller fixture — a live non-destructive probe of the shipped binary) + **L1/L2** for the reusable-workflow job, which is proven only by source assertion and negative mutation because it cannot execute until `0.1.2` is published and a consumer calls it → **L4 required** for the job actually running in a caller. **Residual: the pinned job is unexercised. Residual-Owner: #27 (publication) and #14 (per-repository caller rollout).** Corrected after review: an earlier revision claimed a uniform L4 → L4 with no residual, which credited the workflow with a level nothing in this PR can reach — no L4 destructive handoff is performed here.

## AC Evidence

| AC | Proof |
|---|---|
| AC-1 | **`check-substrate-size.mjs` with a `bin` entry, spec green** — CI-covered: `scripts/test-substrate-size.mjs`, wired into `npm test` and its own `skill-corpus` step; the `bin` entry is asserted by the spec's final arm |
| AC-2 | **absent target → N/A, exits 0** — CI-covered: zero-target fixture arm + partially-populated arm. Outside-CI receipt below: `neo-agent-brain` and `neo-agent-skills` both green at N/A |
| AC-3 | **breach exits non-zero naming file, bytes, limit** — CI-covered: breach arm asserts the count, the limit and `OVER by 1`; process arm asserts `status === 1` |
| AC-4 | **symlink measured as its resolution, `lstat`-only reds** — CI-covered: symlink arm. Mutation receipt below — an `lstat`-size implementation reports **12** where the seat loads **24581** |
| AC-5 | **`@`-imports summed as one unit, cycle terminates** — CI-covered: import arm, own-line-only arm, cycle arm, and a two-names-one-file identity arm |
| AC-6 | **entrypoint guard canonicalizes both operands** — CI-covered: spawned through a symlink, and again under `--preserve-symlinks-main` |
| AC-7 | **`substrate-size` job installs a pinned release into `runner.temp` and runs it against the caller tree** — CI-covered: 9 new contract assertions and 12 negative mutations in `test-reusable-pr-baseline.mjs` (suite total 32) |
| AC-8 | **a caller raising the limit in its own tree still fails** — Outside-CI receipt below — the tampered caller copy exits 0, the pinned guard exits 1 on the same tree |
| AC-9 | **`neomjs/neo#17911` closed as superseded, PR #17912 closed** — `#17911` is `CLOSED`/`NOT_PLANNED`; PR #17912 is `CLOSED`. Neither the Engine workflow nor its script ever merged |

## Deltas from ticket

**One behaviour the ticket did not specify, because it is how the N/A rule would have failed open.** `existsSync` follows symlinks, so a *dangling* entry point answers "absent" — and with absent now meaning N/A, the guard would go silent on a seat whose rules resolve to nothing. Presence is decided by `lstat` instead, which sees the entry itself: present-but-unresolvable is an error, never a skip. That is the discrimination the N/A rule needs to stay honest, and it has its own arm.

**One defect in the port, caught by its own spec.** Member names were computed against an *unresolved* root while imports resolve against the importer's realpath, so any tree reached through a symlink — every macOS temp directory, and any checkout under a linked path — named each imported member by a `../../..` climb out of the tree and back down. Fixed by canonicalizing the root once; an explicit symlinked-root arm covers it on Linux, where `/tmp` would not expose it.

**One property the ticket implied and the contract now enforces:** the guard is invoked **bare**. Every argument narrows what gets measured, so a steered invocation in a shared baseline is the same hole as running the caller's own copy. A mutation adding `--root docs` is red.

Not done, and deliberately: per-repository caller rollout (#25 Out of Scope — the Engine's is the urgent one at 2 bytes), required-context binding, and changing the limit for any repository.

## Test Evidence

### RA-2 (round 2, @neo-gpt): the workspace pin was asserted as an unanchored substring

The pin was in the workflow and asserted in the suite — and the assertion could not fail. `/working-directory: \$\{\{ github\.workspace \}\}/` matched `${{ github.workspace }}/docs`, so a wrong root satisfied the contract forbidding wrong roots. Reproduced before fixing.

Four path-valued assertions shared the defect and are now anchored to end-of-line: the workspace pin, both `SKILLS_ROOT` install roots, and the substrate `ref:`. **The three new mutations append a suffix rather than replacing the value** — a wholesale replacement reds against an unanchored pattern too, so it could not distinguish an anchored assertion from an unanchored one.

Control, both directions, exit codes read unpiped: anchored → `canonical contract + 32 negative mutations passed`, **exit 0**; anchor reverted with the mutation kept → **exit 1** on exactly `substrate workspace pin — suffixed root`. Siblings green at `9cd57a3`: `test-substrate-size`, `test-ticket-archaeology`, `lint-skill-corpus`.

Same class as #28, which I was closing on PR #30 in the same session: substring presence cannot express a positional rule.


**AC-8 — the property the Engine version lacked.** Packed this branch, installed it into a temp prefix, and ran both guards against one caller tree holding a 30,000-byte `AGENTS.md` and its own copy of the script with `PER_FILE_LIMIT_BYTES` raised to 999,999:

```
--- the caller's OWN tampered copy says: ---
✅ AGENTS.md : 30000 bytes · limit 999999 · headroom 969999
caller-copy exit: 0
--- the PINNED guard the job actually runs says: ---
❌ AGENTS.md : 30000 bytes · limit 24576 · OVER by 5424
pinned exit: 1
```

**AC-2 and AC-4 against the real trees.** The same packed guard, run in each consumer checkout:

| repo | result | exit |
|---|---|---|
| `neo` | `AGENTS.md` 24,574 · **headroom 2**; `.claude/CLAUDE.md` 24,574 · **headroom 2** (symlink, measured as its resolution) | 0 |
| `devindex` | `AGENTS.md` 24,272 · **headroom 304**; other targets N/A | 0 |
| `neo-agent-brain` | no entry points — N/A, nothing to measure | 0 |
| `neo-agent-skills` | no entry points — N/A, nothing to measure | 0 |

The `neo` row is AC-4 in production: `lstat` on that symlink reports 12 bytes, the guard reports the 24,574 the seat actually loads, and the file is two bytes from silent truncation.

**Mutation results — seven mutations, each confirmed red for its own reason.** An arm that cannot fail on the defect is not covering it, so every claim above was inverted:

| mutation | arm that caught it |
|---|---|
| `lstat` presence → `existsSync` | `a dangling link is present, not absent` |
| member names against the unresolved root | `and the composition is named` |
| `bytes > limit` → `>=` | `a file exactly at the limit is not a breach` |
| absent target → error (the Engine behaviour) | `every absent target is reported not-applicable` |
| entrypoint guard canonicalizing one side | `under --preserve-symlinks-main, which reverses which side is unresolved` |
| entrypoint guard canonicalizing neither side | `a breach exits 1 as a process` |
| `row.bytes` from `lstat().size` | `the link is measured as what it resolves to` — **actual 12, expected 24581** |

Dropping `realpathSync` from the import walk was also inverted: in isolation the identity arm reports 18 bytes where 9 are loaded, so the same file reached by two names is counted twice.

**Pre-existing, not from this branch.** `npm test` is 24/25 on this branch *and* on a clean `origin/dev` worktree at `d6551c8` — same arm, `a clean non-Neo consumer resolves projected document references`, in `test-lint-skill-corpus.mjs`. CI is green on that same SHA, so the arm is local to this environment — macOS is the axis that differs, not a cause I isolated. Now captured as a defect-note on the zero-ceremony channel (`MESSAGE:7c592d60`), with the ~20 dangling `.claude/skills/*` links in the run output flagged as an unproven lead. It is not this PR's to fix, and this PR does not touch it. The three suites this PR does touch are green: `test-substrate-size.mjs`, `test-reusable-pr-baseline.mjs` (29 mutations), and `lint-skill-corpus.mjs --base origin/dev`.

## Post-Merge Validation

- [ ] **The pinned version must exist on npm before any consumer wires this job.** The baseline pins `SKILLS_VERSION: '0.1.2'` — matching `package.json`, as the contract test requires — but npm's latest is **0.1.1**; `npm view neo-agent-skills@0.1.2` is a 404. This predates my branch and already affects the `source-comment-archaeology` job, which would fail at install for the first consumer that adopts the baseline. No consumer has wired a caller yet, so nothing is red today. Publishing is an operator act, not mine. **Now filed as #27** — including the reason the pin cannot simply be lowered: `test-reusable-pr-baseline.mjs:99`/`:111` assert it equals `package.json`, so lowering it reds the contract test while leaving it reds the first consumer's install.
- [ ] The `substrate-size` check name appears on a consumer PR once the first caller lands, so repository rules can bind it as a required context (#25 Out of Scope; tracked under #14 and `neomjs/neo#17171`).

Residual-Owner: #27

## Commits

- `93dd5e5` — the guard, its spec, the baseline job, and the baseline contract's new assertions

Related: #14. Refs `neomjs/neo#17175`, `neomjs/neo#17171`.

Authored by Grace (Opus 5, Claude Code). Session 2df6c21c-d81d-4e96-82e1-e93dd1ebe6c3.



