### PR TITLE
fix(ci): the PR-body anchor gate refuses a prose mention (#28)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -336,10 +336,10 @@ CI-covered counts (red CI already means no review).>
 
 The shared `PR body` job enforces six **unconditional** anchors (PR #14465), each with a match kind:
 
-- **line** — must open a line; indented ok, a `|` row is not: `## AC Evidence` · `## Test Evidence` · `## Post-Merge Validation` · `## Deltas`
+- **line** — opens a content line, ≤3-space indent; not code or a `|` row: `## AC Evidence` · `## Test Evidence` · `## Post-Merge Validation` · `## Deltas`
 - **substring** — line prefixes, not headings: `Evidence:` · `Authored by `
 
-A `##` anchor in prose is a mention, not the section (`neomjs/neo#17917`: heading gone, 3 mentions left, gate green). Prefixes stay substring: tightening re-opens the false-**negative** `neomjs/neo#14344`, where `- **Evidence:** …` fails for formatting. AC-Evidence CONTENT: Brain preflight, not here (`#24`).
+Code (fenced/indented) is not content; `Resolves #N` must be standalone. A `##` anchor in prose is a mention, not the section (`neomjs/neo#17917`: heading gone, 3 mentions left, gate green). Prefixes stay substring: tightening re-opens `neomjs/neo#14344`. AC-Evidence: Brain preflight (`#24`).
 
 **Evidence discipline (`#10698`):** `Evidence:` declares achieved vs required for sandbox-unreachable runtime/substrate/harness/UI/host effects. Put unavailable-environment residuals in `Evidence:` + `## Post-Merge Validation`. See the [Evidence Ladder](https://github.com/neomjs/neo-agent-brain/blob/dev/learn/agentos/process/evidence-ladder.md); `## AC Evidence` is the author's machine-checked coverage claim, which `pr-review` audits rather than reconstructs.
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -334,7 +334,18 @@ CI-covered counts (red CI already means no review).>
 <one compressed paragraph per pivot — why direction changed, not the old text>
 ```
 
-`agent-pr-body-lint.yml` enforces `Evidence:`, `## AC Evidence`, `## Test Evidence`, `## Post-Merge Validation`, `## Deltas`, `Authored by ` as **unconditional** anchors — presence is never prose-conditional (PR #14465). The AC-Evidence CONTENT is machine-checked too: the lint resolves the close target and fails a certificate that misses the ticket's AC count or leaves a proof slot empty.
+The shared `PR body` baseline job enforces six **unconditional** anchors — presence is never prose-conditional (PR #14465) — and each declares **how it is matched**, because they are not one shape:
+
+| anchor | match |
+|---|---|
+| `## AC Evidence` · `## Test Evidence` · `## Post-Merge Validation` · `## Deltas` | **line** — the anchor must open a line |
+| `Evidence:` · `Authored by ` | **substring** — these are line prefixes, not headings |
+
+**Naming a `##` anchor in prose does not satisfy it.** A sentence explaining why a section was omitted, or a table cell describing it, is a mention rather than the section — measured on `neomjs/neo` PR #17917, deleting the `## Deltas` heading left three surviving prose occurrences and the old substring-only gate stayed green. Indentation is tolerated; a table row (which opens with `|`) is not the anchor line.
+
+The two prefix anchors stay substring deliberately: tightening them would re-open the false-**negative** half recorded in `neomjs/neo#14344`, where a body legitimately carrying `- **Evidence:** …` would begin failing for formatting.
+
+The AC-Evidence CONTENT is machine-checked separately: the lint resolves the close target and fails a certificate that misses the ticket's AC count or leaves a proof slot empty. That half runs in the Brain preflight, not in this job — see `neo-agent-skills#24`.
 
 **Evidence discipline (`#10698`):** `Evidence:` declares achieved vs required for sandbox-unreachable runtime/substrate/harness/UI/host effects. Put unavailable-environment residuals in `Evidence:` + `## Post-Merge Validation`. See the [Evidence Ladder](https://github.com/neomjs/neo-agent-brain/blob/dev/learn/agentos/process/evidence-ladder.md); `## AC Evidence` is the author's machine-checked coverage claim, which `pr-review` audits rather than reconstructs.
 

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -334,18 +334,12 @@ CI-covered counts (red CI already means no review).>
 <one compressed paragraph per pivot — why direction changed, not the old text>
 ```
 
-The shared `PR body` baseline job enforces six **unconditional** anchors — presence is never prose-conditional (PR #14465) — and each declares **how it is matched**, because they are not one shape:
+The shared `PR body` job enforces six **unconditional** anchors (PR #14465), each with a match kind:
 
-| anchor | match |
-|---|---|
-| `## AC Evidence` · `## Test Evidence` · `## Post-Merge Validation` · `## Deltas` | **line** — the anchor must open a line |
-| `Evidence:` · `Authored by ` | **substring** — these are line prefixes, not headings |
+- **line** — must open a line; indented ok, a `|` row is not: `## AC Evidence` · `## Test Evidence` · `## Post-Merge Validation` · `## Deltas`
+- **substring** — line prefixes, not headings: `Evidence:` · `Authored by `
 
-**Naming a `##` anchor in prose does not satisfy it.** A sentence explaining why a section was omitted, or a table cell describing it, is a mention rather than the section — measured on `neomjs/neo` PR #17917, deleting the `## Deltas` heading left three surviving prose occurrences and the old substring-only gate stayed green. Indentation is tolerated; a table row (which opens with `|`) is not the anchor line.
-
-The two prefix anchors stay substring deliberately: tightening them would re-open the false-**negative** half recorded in `neomjs/neo#14344`, where a body legitimately carrying `- **Evidence:** …` would begin failing for formatting.
-
-The AC-Evidence CONTENT is machine-checked separately: the lint resolves the close target and fails a certificate that misses the ticket's AC count or leaves a proof slot empty. That half runs in the Brain preflight, not in this job — see `neo-agent-skills#24`.
+A `##` anchor in prose is a mention, not the section (`neomjs/neo#17917`: heading gone, 3 mentions left, gate green). Prefixes stay substring: tightening re-opens the false-**negative** `neomjs/neo#14344`, where `- **Evidence:** …` fails for formatting. AC-Evidence CONTENT: Brain preflight, not here (`#24`).
 
 **Evidence discipline (`#10698`):** `Evidence:` declares achieved vs required for sandbox-unreachable runtime/substrate/harness/UI/host effects. Put unavailable-environment residuals in `Evidence:` + `## Post-Merge Validation`. See the [Evidence Ladder](https://github.com/neomjs/neo-agent-brain/blob/dev/learn/agentos/process/evidence-ladder.md); `## AC Evidence` is the author's machine-checked coverage claim, which `pr-review` audits rather than reconstructs.
 

--- a/.github/workflows/skill-corpus.yml
+++ b/.github/workflows/skill-corpus.yml
@@ -55,6 +55,12 @@ jobs:
       - name: Substrate budget contract and packed CLI
         run: node scripts/test-substrate-size.mjs
 
+      # Wired HERE as well as in `package.json#test`, because this job runs each suite BY NAME
+      # rather than through `npm test`: a contract added to the package script alone would still
+      # never be selected here, which is exactly how the PR-body contract shipped unexecuted.
+      - name: PR-body anchor contract
+        run: node scripts/test-check-pr-body.mjs
+
       - name: Package contents — what actually ships
         run: |
           TARBALL=$(npm pack --silent | tail -1)
@@ -67,13 +73,15 @@ jobs:
             || { echo "materializer missing from the tarball"; exit 1; }
           tar tzf "$TARBALL" | grep -q 'package/scripts/check-ticket-archaeology.mjs' \
             || { echo "ticket-archaeology CLI missing from the tarball"; exit 1; }
-          # The substrate guard is only a gate if it SHIPS: the baseline job installs the pinned
-          # release and runs it from there, so a CLI absent from the tarball is a job that installs
-          # cleanly and then cannot invoke anything.
+          # A guard is only a gate if it SHIPS: the baseline job installs the pinned release and
+          # runs it from there, so a CLI absent from the tarball is a job that installs cleanly and
+          # then cannot invoke anything.
           tar tzf "$TARBALL" | grep -q 'package/scripts/check-substrate-size.mjs' \
             || { echo "substrate-size CLI missing from the tarball"; exit 1; }
+          tar tzf "$TARBALL" | grep -q 'package/scripts/check-pr-body.mjs' \
+            || { echo "PR-body CLI missing from the tarball"; exit 1; }
 
-          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs' 'package/scripts/test-ticket-archaeology.mjs' 'package/scripts/test-substrate-size.mjs'; do
+          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs' 'package/scripts/test-ticket-archaeology.mjs' 'package/scripts/test-substrate-size.mjs' 'package/scripts/test-check-pr-body.mjs'; do
             tar tzf "$TARBALL" | grep -q "$unwanted" \
               && { echo "$unwanted ships to consumers and should not"; exit 1; }
           done

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     },
     "bin": {
         "neo-agent-skills-materialize"        : "./scripts/materialize-harness-skills.mjs",
+        "neo-agent-skills-pr-body"           : "./scripts/check-pr-body.mjs",
         "neo-agent-skills-substrate-size"    : "./scripts/check-substrate-size.mjs",
         "neo-agent-skills-ticket-archaeology": "./scripts/check-ticket-archaeology.mjs"
     },
@@ -30,6 +31,7 @@
     "files": [
         ".agents/skills",
         "scripts/materialize-harness-skills.mjs",
+        "scripts/check-pr-body.mjs",
         "scripts/check-substrate-size.mjs",
         "scripts/check-ticket-archaeology.mjs",
         "README.md"
@@ -37,7 +39,7 @@
     "scripts": {
         "materialize": "node scripts/materialize-harness-skills.mjs",
         "lint"       : "node scripts/lint-skill-corpus.mjs",
-        "test"       : "node scripts/test-lint-skill-corpus.mjs && node scripts/test-reusable-pr-baseline.mjs && node scripts/test-ticket-archaeology.mjs && node scripts/test-substrate-size.mjs"
+        "test"       : "node scripts/test-lint-skill-corpus.mjs && node scripts/test-reusable-pr-baseline.mjs && node scripts/test-ticket-archaeology.mjs && node scripts/test-substrate-size.mjs && node scripts/test-check-pr-body.mjs"
     },
     "keywords": [
         "neo.mjs",

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -20,7 +20,9 @@ import {fileURLToPath}              from 'node:url';
 
 /**
  * Anchors named in the enumeration a seat reads. A body missing one is told which.
- * @member {String[]} VISIBLE_PR_BODY_ANCHORS
+ * Each entry is a RECORD, not a bare string: the match kind is part of the declaration, because an
+ * unnamed default is how the substring rule survived unexamined.
+ * @member {Array<{anchor: String, match: 'line'|'substring'}>} VISIBLE_PR_BODY_ANCHORS
  */
 export const VISIBLE_PR_BODY_ANCHORS = Object.freeze([
     {anchor: 'Evidence:',                match: 'substring'},
@@ -35,12 +37,55 @@ export const VISIBLE_PR_BODY_ANCHORS = Object.freeze([
  * The split exists to defeat anchor-stuffing: an agent reconstructing a body from the failure
  * message alone produces the visible four and omits these, so the gate still refuses. That defence
  * only holds because the message never names them — it does not make them optional.
- * @member {String[]} INVISIBLE_PR_BODY_ANCHORS
+ * Records, with the same match-kind declaration as the visible set.
+ * @member {Array<{anchor: String, match: 'line'|'substring'}>} INVISIBLE_PR_BODY_ANCHORS
  */
 export const INVISIBLE_PR_BODY_ANCHORS = Object.freeze([
     {anchor: 'Authored by ', match: 'substring'},
     {anchor: '## Deltas',    match: 'line'}
 ]);
+
+/**
+ * @summary The body's PROSE lines — everything a reader would call content.
+ *
+ * Removes fenced blocks (``` and ~~~, any info string, closed or unterminated) and indented code
+ * blocks (four or more leading spaces). Both are places an anchor can *appear* without the section
+ * existing, which is the same defect as a prose mention one level in: the first fix taught the gate
+ * that a sentence naming `## Deltas` is not the section, and left it believing that a fenced or
+ * indented `## Deltas` is.
+ *
+ * A four-space line is only code when it is not a list continuation, but this guard deliberately
+ * takes the stricter reading: a required section heading nested four spaces deep inside a list is
+ * not a section either, so treating it as code costs nothing real and closes the evasion.
+ *
+ * @param {String} body
+ * @returns {String[]} Lines outside every fence and indented-code block, in order.
+ */
+export function markdownContentLines(body = '') {
+    const lines = String(body).split('\n'),
+          out   = [];
+
+    let fence = null;
+
+    for (const line of lines) {
+        const opener = line.match(/^ {0,3}(`{3,}|~{3,})/);
+
+        if (fence) {
+            // A closing fence must use the same character and be at least as long as the opener.
+            if (opener && opener[1][0] === fence[0] && opener[1].length >= fence.length) fence = null;
+            continue
+        }
+
+        if (opener) { fence = opener[1]; continue }
+
+        // Indented code. Tabs count as indentation too, and a blank line is neither.
+        if (/^(?: {4,}|\t)/.test(line)) continue;
+
+        out.push(line)
+    }
+
+    return out
+}
 
 /**
  * @summary Is this anchor present, under the match kind its declaration names?
@@ -69,12 +114,19 @@ export const INVISIBLE_PR_BODY_ANCHORS = Object.freeze([
  * @throws {Error} When the anchor declares no match kind.
  */
 export function hasAnchor(body, {anchor, match}) {
+    const lines = markdownContentLines(body);
+
     if (match === 'line') {
-        // Leading whitespace is tolerated: indentation is formatting, not evasion.
-        return body.split('\n').some(line => line.replace(/^[ \t]+/, '').startsWith(anchor))
+        // At most Markdown's permitted heading indentation. Four spaces opens an indented code
+        // block, which `markdownContentLines` has already removed — this bound is what stops a
+        // three-space heading being rejected as formatting while keeping the code-block door shut.
+        return lines.some(line => /^ {0,3}\S/.test(line) && line.trimStart().startsWith(anchor))
     }
 
-    if (match === 'substring') return body.includes(anchor);
+    // Substring anchors are matched against CONTENT too, not the raw body. A fenced `Evidence:`
+    // is documentation of the anchor, not the anchor. This does not re-open `neomjs/neo#14344`:
+    // that false negative was a real `- **Evidence:** …` content line, which still matches.
+    if (match === 'substring') return lines.join('\n').includes(anchor);
 
     // No default. An anchor whose match kind is absent is a declaration error, not a body error,
     // and silently picking one is how the original defect survived unnamed for months.
@@ -96,10 +148,18 @@ export function findBodyViolations({body = '', isDraft = false} = {}) {
         visible   = VISIBLE_PR_BODY_ANCHORS.filter(spec => !hasAnchor(body, spec)).map(spec => spec.anchor),
         invisible = INVISIBLE_PR_BODY_ANCHORS.filter(spec => !hasAnchor(body, spec)).map(spec => spec.anchor),
 
-        // Ticket reference is a pattern, not an anchor: it may legitimately appear mid-line.
-        hasResolves            = /\bResolves:?\s+#\d+/i.test(body),
-        hasNonClosingReference = /\b(?:Refs|Related):?\s+#\d+/i.test(body),
-        forbiddenClose         = body.match(/\b(Closes|Fixes):?\s+#\d+/i);
+        // The close target is a STANDALONE line, which is what `pull-request-workflow.md` §9.1
+        // has always promised ("standalone Resolves #TICKET_ID"). The previous pattern searched
+        // the raw body, so `This PR Resolves #1234 as a side effect.`, a fenced example, a table
+        // cell and `Resolves #1, #2` all satisfied a rule that forbids every one of them. A close
+        // target is a machine-read declaration; prose that happens to contain the words is not one.
+        content    = markdownContentLines(body).map(line => line.trim()),
+        hasResolves            = content.some(line => /^Resolves #\d+$/.test(line)),
+        hasNonClosingReference = content.some(line => /^(?:Refs #\d+|Related: #\d+)$/.test(line)),
+        forbiddenClose         = content.map(line => line.match(/^(Closes|Fixes):?\s+#\d+/i)).find(Boolean),
+        // §9.1 forbids the comma form explicitly: multiple delivered tickets get one standalone
+        // line each. Reported separately from "absent" so the author is told which rule they hit.
+        commaSeparated         = content.some(line => /^Resolves #\d+\s*,/.test(line));
 
     // `Closes` means closed-without-delivery, an outcome that needs no pull request at all;
     // `Fixes` is ambiguous. One sanctioned closing keyword keeps the 1-PR-per-ticket model
@@ -108,10 +168,16 @@ export function findBodyViolations({body = '', isDraft = false} = {}) {
         visible.push(`\`${forbiddenClose[1]} #N\` is forbidden — use \`Resolves #N\``)
     }
 
+    // Named before the absence check, because `Resolves #1, #2` IS a close target the author
+    // wrote deliberately — telling them it is "missing" sends them looking for the wrong bug.
+    if (commaSeparated) {
+        visible.push('`Resolves #X, #Y` is forbidden — one standalone `Resolves #N` line per delivered ticket')
+    }
+
     if (!hasResolves && !(isDraft && hasNonClosingReference)) {
         visible.push(isDraft
-            ? '`Refs #N` or `Related: #N` (draft-only non-closing reference, required while `Resolves #N` is absent)'
-            : '`Resolves #N` (mandatory closing keyword — `Refs`/`Related` alone is not sufficient)')
+            ? '`Refs #N` or `Related: #N` on its own line (draft-only non-closing reference, required while `Resolves #N` is absent)'
+            : '`Resolves #N` on its own line (mandatory closing keyword — `Refs`/`Related` alone is not sufficient, and a mention inside prose, a table cell or a fence is not a declaration)')
     }
 
     return {invisible, visible}

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * @summary Validates an agent pull-request body against the anchors `pull-request-workflow.md` §9 promises.
+ *
+ * The decision half only. It receives a body and returns findings; it never fetches a pull request,
+ * never posts a comment, and never reads the network. The reusable workflow owns event acquisition,
+ * the live body read and the corrective comment — so this file is testable as a pure function, which
+ * is the property the previous home could not have.
+ *
+ * **Why this is not the workflow it replaces.** The gate lived as 253 lines of inline
+ * `actions/github-script` inside a single repository's YAML. Inline logic cannot carry a
+ * `test-*.mjs` contract, and a guard living in the tree it guards can be weakened by the diff it
+ * guards. Both are fixed by being here: consumers call one stable job through an immutable release.
+ */
+
+import {readFileSync, realpathSync} from 'node:fs';
+import process                      from 'node:process';
+import {parseArgs}                  from 'node:util';
+import {fileURLToPath}              from 'node:url';
+
+/**
+ * Anchors named in the enumeration a seat reads. A body missing one is told which.
+ * @member {String[]} VISIBLE_PR_BODY_ANCHORS
+ */
+export const VISIBLE_PR_BODY_ANCHORS = Object.freeze([
+    'Evidence:',
+    '## AC Evidence',
+    '## Test Evidence',
+    '## Post-Merge Validation'
+]);
+
+/**
+ * Anchors deliberately absent from the diagnostic enumeration.
+ *
+ * The split exists to defeat anchor-stuffing: an agent reconstructing a body from the failure
+ * message alone produces the visible four and omits these, so the gate still refuses. That defence
+ * only holds because the message never names them — it does not make them optional.
+ * @member {String[]} INVISIBLE_PR_BODY_ANCHORS
+ */
+export const INVISIBLE_PR_BODY_ANCHORS = Object.freeze(['Authored by ', '## Deltas']);
+
+/**
+ * @summary Is this anchor present as a LINE, rather than anywhere in the prose?
+ *
+ * The previous implementation used `body.includes(anchor)` — a substring test against the whole
+ * body — and that is the defect this port exists to close. Every anchor also appears in bodies that
+ * *discuss* the anchors: a table cell describing `## Test Evidence`, or a sentence explaining why a
+ * section was omitted, satisfied the gate while the section itself was absent. Measured on the
+ * restoration PR: deleting the `## Deltas` heading left three surviving prose occurrences and the
+ * check stayed green; only erasing every occurrence of an anchor reddened it.
+ *
+ * Line-anchoring covers both anchor shapes without a second rule. `## AC Evidence` is a heading and
+ * `Evidence:` / `Authored by ` are line-initial prefixes; all three open a line. A mention inside a
+ * sentence, a table row (which opens with `|`), or a fenced snippet does not.
+ *
+ * Leading whitespace is tolerated because indentation is formatting, not evasion.
+ * @param {String} body
+ * @param {String} anchor
+ * @returns {Boolean}
+ */
+export function hasAnchorLine(body, anchor) {
+    return body.split('\n').some(line => line.replace(/^[ \t]+/, '').startsWith(anchor))
+}
+
+/**
+ * @summary Returns every reason this body must be refused, in the order a reader should fix them.
+ *
+ * Pure and transport-free: the same body yields the same findings whether it came from a webhook, a
+ * local file, or a test fixture.
+ * @param {Object} options
+ * @param {String} options.body Pull-request body.
+ * @param {Boolean} [options.isDraft=false] Draft pull requests may defer the close target.
+ * @returns {{visible: String[], invisible: String[]}} `invisible` is never surfaced in prose.
+ */
+export function findBodyViolations({body = '', isDraft = false} = {}) {
+    const
+        visible   = VISIBLE_PR_BODY_ANCHORS.filter(anchor => !hasAnchorLine(body, anchor)),
+        invisible = INVISIBLE_PR_BODY_ANCHORS.filter(anchor => !hasAnchorLine(body, anchor)),
+
+        // Ticket reference is a pattern, not an anchor: it may legitimately appear mid-line.
+        hasResolves            = /\bResolves:?\s+#\d+/i.test(body),
+        hasNonClosingReference = /\b(?:Refs|Related):?\s+#\d+/i.test(body),
+        forbiddenClose         = body.match(/\b(Closes|Fixes):?\s+#\d+/i);
+
+    // `Closes` means closed-without-delivery, an outcome that needs no pull request at all;
+    // `Fixes` is ambiguous. One sanctioned closing keyword keeps the 1-PR-per-ticket model
+    // mechanical: a ticket needing N pull requests cannot carry N valid `Resolves`.
+    if (forbiddenClose) {
+        visible.push(`\`${forbiddenClose[1]} #N\` is forbidden — use \`Resolves #N\``)
+    }
+
+    if (!hasResolves && !(isDraft && hasNonClosingReference)) {
+        visible.push(isDraft
+            ? '`Refs #N` or `Related: #N` (draft-only non-closing reference, required while `Resolves #N` is absent)'
+            : '`Resolves #N` (mandatory closing keyword — `Refs`/`Related` alone is not sufficient)')
+    }
+
+    return {invisible, visible}
+}
+
+/**
+ * @summary CLI entry. Reads a body from a file or stdin and reports findings.
+ * @param {String[]} [argv]
+ * @param {Object} [options={}]
+ * @param {Function} [options.out=console.log]
+ * @param {Function} [options.error=console.error]
+ * @param {String} [options.stdin] Body text, when not read from `--body-file`.
+ * @returns {Number} Exit code.
+ */
+export function run(argv = process.argv.slice(2), {out = console.log, error = console.error, stdin = ''} = {}) {
+    const parsed = parseArgs({
+        args            : argv,
+        allowPositionals: false,
+        strict          : true,
+        options         : {'body-file': {type: 'string'}, draft: {type: 'boolean', default: false}}
+    });
+
+    let body = stdin;
+
+    if (parsed.values['body-file']) {
+        try {
+            body = readFileSync(parsed.values['body-file'], 'utf8')
+        } catch (cause) {
+            error(`check-pr-body: cannot read ${parsed.values['body-file']} — ${cause.message}`);
+            return 1
+        }
+    }
+
+    const {invisible, visible} = findBodyViolations({body, isDraft: parsed.values.draft});
+
+    if (!visible.length && !invisible.length) {
+        out('✅ PR body carries every required anchor.');
+        return 0
+    }
+
+    error('❌ Agent PR body is missing required template anchors.');
+
+    // At most ONE diagnostic anchor in prose, and never an invisible one. A failure message that
+    // enumerates the full set is a template an agent can satisfy without writing the sections.
+    visible[0] && error(`   First missing: ${visible[0]}`);
+
+    error('   Anchors are matched as LINES, not substrings — naming one in prose does not satisfy it.');
+    error('   See .agents/skills/pull-request/references/pull-request-workflow.md §9.');
+
+    return 1
+}
+
+// Entrypoint guard, canonicalized on BOTH sides: realpathing only `argv[1]` still disagrees under
+// `--preserve-symlinks-main`, where node keeps the link path in `import.meta.url`. The module would
+// load, `run()` would never execute, and the process would exit 0 — a guard that stops guarding.
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))) {
+    const chunks = [];
+
+    process.stdin.on('data', chunk => chunks.push(chunk))
+        .on('end', () => process.exit(run(process.argv.slice(2), {stdin: chunks.join('')})));
+
+    // No piped stdin: `--body-file` supplies the body instead.
+    process.stdin.isTTY && process.exit(run());
+}

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -23,10 +23,10 @@ import {fileURLToPath}              from 'node:url';
  * @member {String[]} VISIBLE_PR_BODY_ANCHORS
  */
 export const VISIBLE_PR_BODY_ANCHORS = Object.freeze([
-    'Evidence:',
-    '## AC Evidence',
-    '## Test Evidence',
-    '## Post-Merge Validation'
+    {anchor: 'Evidence:',                match: 'substring'},
+    {anchor: '## AC Evidence',           match: 'line'},
+    {anchor: '## Test Evidence',         match: 'line'},
+    {anchor: '## Post-Merge Validation', match: 'line'}
 ]);
 
 /**
@@ -37,29 +37,48 @@ export const VISIBLE_PR_BODY_ANCHORS = Object.freeze([
  * only holds because the message never names them — it does not make them optional.
  * @member {String[]} INVISIBLE_PR_BODY_ANCHORS
  */
-export const INVISIBLE_PR_BODY_ANCHORS = Object.freeze(['Authored by ', '## Deltas']);
+export const INVISIBLE_PR_BODY_ANCHORS = Object.freeze([
+    {anchor: 'Authored by ', match: 'substring'},
+    {anchor: '## Deltas',    match: 'line'}
+]);
 
 /**
- * @summary Is this anchor present as a LINE, rather than anywhere in the prose?
+ * @summary Is this anchor present, under the match kind its declaration names?
  *
- * The previous implementation used `body.includes(anchor)` — a substring test against the whole
- * body — and that is the defect this port exists to close. Every anchor also appears in bodies that
- * *discuss* the anchors: a table cell describing `## Test Evidence`, or a sentence explaining why a
- * section was omitted, satisfied the gate while the section itself was absent. Measured on the
- * restoration PR: deleting the `## Deltas` heading left three surviving prose occurrences and the
- * check stayed green; only erasing every occurrence of an anchor reddened it.
+ * The previous implementation matched every anchor with `body.includes(anchor)` against the whole
+ * body. Every anchor also appears in bodies that *discuss* the anchors, so a table cell describing
+ * `## Test Evidence`, or a sentence explaining why a section was omitted, satisfied the gate while
+ * the section itself was absent. Measured on the restoration PR: deleting the `## Deltas` heading
+ * left three surviving prose occurrences and the check stayed green.
  *
- * Line-anchoring covers both anchor shapes without a second rule. `## AC Evidence` is a heading and
- * `Evidence:` / `Authored by ` are line-initial prefixes; all three open a line. A mention inside a
- * sentence, a table row (which opens with `|`), or a fenced snippet does not.
+ * **The kinds are per anchor and deliberately not uniform**, because the anchors are not one shape.
+ * The four `##` anchors are headings and are line-anchored — a mention inside a sentence, a table row
+ * (which opens with `|`), or a fenced snippet no longer counts. `Evidence:` and `Authored by ` are
+ * not headings and stay substring, because tightening them would re-open the false-NEGATIVE half
+ * already recorded as `neomjs/neo#14344`: a body legitimately carrying `- **Evidence:** …` or a
+ * signature line would start failing for formatting.
  *
- * Leading whitespace is tolerated because indentation is formatting, not evasion.
+ * Every anchor therefore declares its kind and there is **no default** — an undeclared anchor throws
+ * rather than silently picking one, since an unnamed default is how the original defect went
+ * unnoticed.
  * @param {String} body
- * @param {String} anchor
+ * @param {Object} spec
+ * @param {String} spec.anchor
+ * @param {'line'|'substring'} spec.match
  * @returns {Boolean}
+ * @throws {Error} When the anchor declares no match kind.
  */
-export function hasAnchorLine(body, anchor) {
-    return body.split('\n').some(line => line.replace(/^[ \t]+/, '').startsWith(anchor))
+export function hasAnchor(body, {anchor, match}) {
+    if (match === 'line') {
+        // Leading whitespace is tolerated: indentation is formatting, not evasion.
+        return body.split('\n').some(line => line.replace(/^[ \t]+/, '').startsWith(anchor))
+    }
+
+    if (match === 'substring') return body.includes(anchor);
+
+    // No default. An anchor whose match kind is absent is a declaration error, not a body error,
+    // and silently picking one is how the original defect survived unnamed for months.
+    throw new Error(`check-pr-body: anchor "${anchor}" declares no match kind`)
 }
 
 /**
@@ -74,8 +93,8 @@ export function hasAnchorLine(body, anchor) {
  */
 export function findBodyViolations({body = '', isDraft = false} = {}) {
     const
-        visible   = VISIBLE_PR_BODY_ANCHORS.filter(anchor => !hasAnchorLine(body, anchor)),
-        invisible = INVISIBLE_PR_BODY_ANCHORS.filter(anchor => !hasAnchorLine(body, anchor)),
+        visible   = VISIBLE_PR_BODY_ANCHORS.filter(spec => !hasAnchor(body, spec)).map(spec => spec.anchor),
+        invisible = INVISIBLE_PR_BODY_ANCHORS.filter(spec => !hasAnchor(body, spec)).map(spec => spec.anchor),
 
         // Ticket reference is a pattern, not an anchor: it may legitimately appear mid-line.
         hasResolves            = /\bResolves:?\s+#\d+/i.test(body),
@@ -139,7 +158,7 @@ export function run(argv = process.argv.slice(2), {out = console.log, error = co
     // enumerates the full set is a template an agent can satisfy without writing the sections.
     visible[0] && error(`   First missing: ${visible[0]}`);
 
-    error('   Anchors are matched as LINES, not substrings — naming one in prose does not satisfy it.');
+    error('   `##` section anchors must open a LINE — naming one in prose does not satisfy it.');
     error('   See .agents/skills/pull-request/references/pull-request-workflow.md §9.');
 
     return 1

--- a/scripts/test-check-pr-body.mjs
+++ b/scripts/test-check-pr-body.mjs
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/** @summary Mutation-sensitive contract checks for the portable PR-body anchor guard. */
+
+import assert                                   from 'node:assert/strict';
+import {spawnSync}                              from 'node:child_process';
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir}                                 from 'node:os';
+import {dirname, join}                          from 'node:path';
+import {fileURLToPath}                          from 'node:url';
+import {VISIBLE_PR_BODY_ANCHORS, INVISIBLE_PR_BODY_ANCHORS, findBodyViolations, hasAnchorLine, run} from './check-pr-body.mjs';
+
+const
+    here      = dirname(fileURLToPath(import.meta.url)),
+    GUARD     = join(here, 'check-pr-body.mjs'),
+    // macOS resolves /tmp through a symlink and one arm below asserts what node does with a
+    // symlinked entrypoint. Spawning the already-resolved path would decide that arm before it runs.
+    CLI_GUARD = GUARD.startsWith('/private/tmp/') ? GUARD.replace('/private/tmp/', '/tmp/') : GUARD,
+    scratch   = [];
+
+/** @summary A body carrying every anchor as a real line, plus a close target. */
+function goodBody(extra = '') {
+    return [
+        'Resolves #1234',
+        '',
+        'Evidence: L2 (unit) → L2 required. No residuals.',
+        '',
+        '## AC Evidence',
+        '| AC-1 | covered |',
+        '',
+        '## Deltas from ticket',
+        'None substantive.',
+        '',
+        '## Test Evidence',
+        'All coverage runs in CI.',
+        '',
+        '## Post-Merge Validation',
+        'None.',
+        '',
+        'Authored by @neo-opus-grace.',
+        extra
+    ].join('\n')
+}
+
+/** @summary Runs the CLI as a real process. */
+function cli(args, body) {
+    const dir  = mkdtempSync(join(tmpdir(), 'pr-body-'));
+    const file = join(dir, 'body.md');
+
+    scratch.push(dir);
+    writeFileSync(file, body);
+
+    const result = spawnSync(process.execPath, [CLI_GUARD, '--body-file', file, ...args], {encoding: 'utf8'});
+
+    return {code: result.status, text: `${result.stdout}${result.stderr}`}
+}
+
+// ── The canonical body passes ──────────────────────────────────────────────────────────────────
+{
+    const {visible, invisible} = findBodyViolations({body: goodBody()});
+
+    assert.deepEqual(visible, [], 'a complete body must report no visible misses');
+    assert.deepEqual(invisible, [], 'a complete body must report no invisible misses');
+    assert.equal(cli([], goodBody()).code, 0)
+}
+
+// ── THE #28 DEFECT: naming an anchor in prose must NOT satisfy it ──────────────────────────────
+//
+// The previous gate used `body.includes(anchor)` against the whole body. Every anchor also appears
+// in bodies that DISCUSS the anchors, so a body that never carried the section passed by mentioning
+// it. Measured on the restoration PR: deleting the `## Deltas` heading left three surviving prose
+// occurrences and the check stayed green.
+//
+// Each arm below removes one anchor's LINE while leaving the anchor's text in prose. Under the old
+// substring rule every one of these was green.
+VISIBLE_PR_BODY_ANCHORS.concat(INVISIBLE_PR_BODY_ANCHORS).forEach(anchor => {
+    const body = goodBody()
+        .split('\n')
+        .filter(line => !line.replace(/^[ \t]+/, '').startsWith(anchor))
+        .concat([`This PR intentionally omits ${anchor} because everything runs in CI.`])
+        .join('\n');
+
+    assert.ok(body.includes(anchor), `fixture must still MENTION ${anchor}, or it proves nothing`);
+
+    const {visible, invisible} = findBodyViolations({body});
+
+    assert.ok(
+        visible.includes(anchor) || invisible.includes(anchor),
+        `naming "${anchor}" in prose must not satisfy it — this is the #28 defect`
+    );
+
+    assert.equal(cli([], body).code, 1, `a prose-only "${anchor}" must exit non-zero`)
+});
+
+// ── A table cell does not satisfy an anchor ────────────────────────────────────────────────────
+{
+    assert.equal(hasAnchorLine('| ## Test Evidence | present |', '## Test Evidence'), false,
+        'a table row opens with `|`, so it is not the anchor line');
+    assert.equal(hasAnchorLine('   ## Test Evidence', '## Test Evidence'), true,
+        'indentation is formatting, not evasion')
+}
+
+// ── The close-target rules ─────────────────────────────────────────────────────────────────────
+{
+    const noResolves = goodBody().replace('Resolves #1234', 'Refs #1234');
+
+    assert.ok(findBodyViolations({body: noResolves}).visible.some(v => v.includes('Resolves #N')),
+        'a non-draft body without `Resolves #N` must be refused');
+
+    assert.deepEqual(findBodyViolations({body: noResolves, isDraft: true}).visible, [],
+        'a DRAFT may defer the close target when it carries `Refs #N`');
+
+    assert.ok(findBodyViolations({body: goodBody().replace('Resolves #1234', 'Closes #1234')})
+        .visible.some(v => v.includes('forbidden')), '`Closes #N` must be refused');
+
+    assert.ok(findBodyViolations({body: goodBody().replace('Resolves #1234', 'Fixes #1234')})
+        .visible.some(v => v.includes('forbidden')), '`Fixes #N` must be refused')
+}
+
+// ── The failure message never enumerates the anchor set ────────────────────────────────────────
+//
+// A message listing every missing anchor is a template an agent can satisfy without writing the
+// sections — the anchor-stuffing this split exists to defeat. At most one diagnostic anchor, and
+// never an invisible one.
+{
+    const body = goodBody().split('\n').filter(line => !line.startsWith('Authored by ')).join('\n'),
+          {text} = cli([], body);
+
+    INVISIBLE_PR_BODY_ANCHORS.forEach(anchor => {
+        assert.ok(!text.includes(anchor), `the failure message must never name the invisible anchor ${anchor}`)
+    })
+}
+
+// ── The CLI ships with a bin entry, or consumers cannot invoke it ──────────────────────────────
+{
+    const pkg = JSON.parse(readFileSync(join(here, '../package.json'), 'utf8'));
+
+    assert.equal(pkg.bin['neo-agent-skills-pr-body'], './scripts/check-pr-body.mjs');
+    assert.ok(pkg.files.includes('scripts/check-pr-body.mjs'), 'the guard must ship in the package')
+}
+
+scratch.forEach(dir => rmSync(dir, {force: true, recursive: true}));
+
+console.log('check-pr-body: contract arms green.');

--- a/scripts/test-check-pr-body.mjs
+++ b/scripts/test-check-pr-body.mjs
@@ -164,6 +164,82 @@ VISIBLE_PR_BODY_ANCHORS.concat(INVISIBLE_PR_BODY_ANCHORS).filter(spec => spec.ma
     })
 }
 
+// ── A CODE anchor is not a section: fenced and indented blocks are not content ─────────────────
+//
+// The first fix taught the gate that a sentence naming `## Deltas` is not the section, and left it
+// believing a FENCED one is. Same defect, one level in. Both arms delete the real line and leave
+// the anchor visible in a place a reader would call code.
+{
+    const withoutTestEvidence = goodBody()
+        .split('\n').filter(line => !line.startsWith('## Test Evidence')).join('\n');
+
+    const fenced = `${withoutTestEvidence}\n\n\`\`\`md\n## Test Evidence\n\`\`\`\n`,
+          tilde  = `${withoutTestEvidence}\n\n~~~\n## Test Evidence\n~~~\n`,
+          indent = `${withoutTestEvidence}\n\n    ## Test Evidence\n`,
+          tabbed = `${withoutTestEvidence}\n\n\t## Test Evidence\n`;
+
+    [['fenced', fenced], ['tilde-fenced', tilde], ['4-space indented', indent], ['tab indented', tabbed]]
+        .forEach(([label, body]) => {
+            assert.ok(body.includes('## Test Evidence'), `${label}: fixture must still CONTAIN the anchor`);
+            assert.ok(findBodyViolations({body}).visible.includes('## Test Evidence'),
+                `a ${label} "## Test Evidence" must not satisfy the anchor`);
+            assert.equal(cli([], body).code, 1, `${label} must exit non-zero`)
+        });
+
+    // NO OVERSHOOT: Markdown permits up to three spaces before a heading, and a real body may
+    // carry one. Rejecting that would trade this defect for a false negative.
+    const threeSpace = withoutTestEvidence.replace('## AC Evidence', '   ## Test Evidence\n\n## AC Evidence');
+
+    assert.deepEqual(findBodyViolations({body: threeSpace}).visible, [],
+        'a heading indented three spaces is still a heading');
+
+    // An unterminated fence swallows the rest of the body — a real hazard, so it is asserted
+    // rather than left to chance.
+    const unterminated = `${goodBody()}\n\n\`\`\`\n## Test Evidence\n`;
+
+    assert.deepEqual(findBodyViolations({body: unterminated}).visible, [],
+        'the REAL sections above an unterminated fence still count');
+}
+
+// ── The close target is a STANDALONE line, exactly as §9.1 promises ────────────────────────────
+//
+// `pull-request-workflow.md` §9.1: "standalone Resolves #TICKET_ID", and "comma-separated
+// `Resolves #X, #Y` is forbidden". The previous pattern searched the whole raw body, so every
+// mutant below satisfied a rule that forbids it.
+{
+    const withoutResolves = goodBody()
+        .split('\n').filter(line => !line.startsWith('Resolves ')).join('\n');
+
+    const mutants = {
+        'mid-prose'  : 'This PR Resolves #1234 as a side effect.',
+        'fenced'     : '```\nResolves #1234\n```',
+        'table cell' : '| note | Resolves #1234 |',
+        'indented'   : '    Resolves #1234',
+        'colon form' : 'Resolves: #1234'
+    };
+
+    Object.entries(mutants).forEach(([label, line]) => {
+        const body = `${line}\n${withoutResolves}`;
+
+        assert.ok(body.includes('Resolves'), `${label}: fixture must still MENTION Resolves`);
+        assert.ok(findBodyViolations({body}).visible.some(v => v.includes('Resolves #N')),
+            `a ${label} "Resolves" must not satisfy the close target`)
+    });
+
+    // The comma form is a close target the author wrote DELIBERATELY, so it earns its own message
+    // rather than being reported as absent.
+    const comma = `Resolves #1234, #5678\n${withoutResolves}`;
+
+    assert.ok(findBodyViolations({body: comma}).visible.some(v => v.includes('`Resolves #X, #Y` is forbidden')),
+        'the comma form must be named as forbidden, not merely reported missing');
+
+    // Draft exception survives, and it is standalone too.
+    assert.deepEqual(findBodyViolations({body: `Refs #1234\n${withoutResolves}`, isDraft: true}).visible, [],
+        'a DRAFT may defer the close target with a standalone `Refs #N`');
+    assert.ok(findBodyViolations({body: `see Refs #1234 inline\n${withoutResolves}`, isDraft: true})
+        .visible.some(v => v.includes('Refs #N')), 'an inline `Refs` is not a declaration either')
+}
+
 // ── The CLI ships with a bin entry, or consumers cannot invoke it ──────────────────────────────
 {
     const pkg = JSON.parse(readFileSync(join(here, '../package.json'), 'utf8'));

--- a/scripts/test-check-pr-body.mjs
+++ b/scripts/test-check-pr-body.mjs
@@ -7,7 +7,7 @@ import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir}                                 from 'node:os';
 import {dirname, join}                          from 'node:path';
 import {fileURLToPath}                          from 'node:url';
-import {VISIBLE_PR_BODY_ANCHORS, INVISIBLE_PR_BODY_ANCHORS, findBodyViolations, hasAnchorLine, run} from './check-pr-body.mjs';
+import {VISIBLE_PR_BODY_ANCHORS, INVISIBLE_PR_BODY_ANCHORS, findBodyViolations, hasAnchor, run} from './check-pr-body.mjs';
 
 const
     here      = dirname(fileURLToPath(import.meta.url)),
@@ -72,7 +72,7 @@ function cli(args, body) {
 //
 // Each arm below removes one anchor's LINE while leaving the anchor's text in prose. Under the old
 // substring rule every one of these was green.
-VISIBLE_PR_BODY_ANCHORS.concat(INVISIBLE_PR_BODY_ANCHORS).forEach(anchor => {
+VISIBLE_PR_BODY_ANCHORS.concat(INVISIBLE_PR_BODY_ANCHORS).filter(spec => spec.match === 'line').forEach(({anchor}) => {
     const body = goodBody()
         .split('\n')
         .filter(line => !line.replace(/^[ \t]+/, '').startsWith(anchor))
@@ -93,9 +93,9 @@ VISIBLE_PR_BODY_ANCHORS.concat(INVISIBLE_PR_BODY_ANCHORS).forEach(anchor => {
 
 // ── A table cell does not satisfy an anchor ────────────────────────────────────────────────────
 {
-    assert.equal(hasAnchorLine('| ## Test Evidence | present |', '## Test Evidence'), false,
+    assert.equal(hasAnchor('| ## Test Evidence | present |', {anchor: '## Test Evidence', match: 'line'}), false,
         'a table row opens with `|`, so it is not the anchor line');
-    assert.equal(hasAnchorLine('   ## Test Evidence', '## Test Evidence'), true,
+    assert.equal(hasAnchor('   ## Test Evidence', {anchor: '## Test Evidence', match: 'line'}), true,
         'indentation is formatting, not evasion')
 }
 
@@ -125,8 +125,42 @@ VISIBLE_PR_BODY_ANCHORS.concat(INVISIBLE_PR_BODY_ANCHORS).forEach(anchor => {
     const body = goodBody().split('\n').filter(line => !line.startsWith('Authored by ')).join('\n'),
           {text} = cli([], body);
 
-    INVISIBLE_PR_BODY_ANCHORS.forEach(anchor => {
+    INVISIBLE_PR_BODY_ANCHORS.forEach(({anchor}) => {
         assert.ok(!text.includes(anchor), `the failure message must never name the invisible anchor ${anchor}`)
+    })
+}
+
+// ── NO REGRESSION: a governance body that DISCUSSES the anchor set stays green ─────────────────
+//
+// The arm that keeps the fix from overshooting. Bodies in this repository routinely name every
+// anchor in prose while also carrying the sections — this comment block does it. Line-anchoring
+// must refuse a body that only *mentions* an anchor without refusing one that mentions AND carries.
+{
+    const discursive = goodBody([
+        '',
+        'This PR explains the anchor set: `## AC Evidence` certifies coverage, `## Test Evidence`',
+        'carries outside-CI receipts, `## Post-Merge Validation` lists deferred checks, and',
+        '`## Deltas` records scope changes. `Evidence:` and `Authored by ` are line prefixes.'
+    ].join('\n'));
+
+    const {visible, invisible} = findBodyViolations({body: discursive});
+
+    assert.deepEqual(visible, [], 'a body that discusses the anchors AND carries them must stay green');
+    assert.deepEqual(invisible, [], 'discussion must not disturb the invisible anchors either');
+    assert.equal(cli([], discursive).code, 0)
+}
+
+// ── An anchor with no declared match kind THROWS rather than picking one ────────────────────────
+//
+// An unnamed default is how the substring rule survived unexamined: nobody chose it, so nobody
+// reviewed it. A declaration error must be loud at the point of declaration.
+{
+    assert.throws(() => hasAnchor('anything', {anchor: '## Nope'}), /declares no match kind/,
+        'an undeclared match kind must throw, not default');
+
+    [...VISIBLE_PR_BODY_ANCHORS, ...INVISIBLE_PR_BODY_ANCHORS].forEach(spec => {
+        assert.ok(['line', 'substring'].includes(spec.match),
+            `${spec.anchor} must declare a known match kind, not "${spec.match}"`)
     })
 }
 


### PR DESCRIPTION
Resolves #28

Refs #29

The PR-body anchor gate's decision half, as a portable guard, with #28's substring defect closed by construction. The reusable-workflow job is deliberately **not** here: #26 owns `reusable-pr-baseline.yml` and is still in review, so stacking the job would conflict on one file. That slice stays on #29.

Evidence: **L2** (the validator is a pure function driven by fixtures, plus the CLI exercised as a real process against body files) → **L4 required** for #28's AC-6, which needs a published release and a caller before any consumer can report the check. **Residual: AC-6, Residual-Owner: #29** (the job); #14 owns the per-repository callers.

## AC Evidence

| AC | Proof |
| --- | --- |
| AC-1 | outside-CI: `VISIBLE_PR_BODY_ANCHORS` / `INVISIBLE_PR_BODY_ANCHORS` are `{anchor, match}` records; `hasAnchor` **throws** on an unnamed kind rather than defaulting. Arms: `assert.throws(… /declares no match kind/)`, plus a sweep asserting every declared anchor names `line` or `substring` |
| AC-2 | outside-CI: the four `##` anchors declare `match: 'line'`; `Evidence:` and `Authored by ` declare `match: 'substring'`. Asserted structurally by the AC-1 sweep and behaviourally by AC-3's per-anchor arms, which iterate only `match === 'line'` |
| AC-3 | outside-CI: one arm per `##` anchor deletes its line, appends a sentence naming it, asserts the fixture still contains the anchor as a substring, then asserts refusal — `node scripts/test-check-pr-body.mjs`. **Shown failing against the substring implementation first:** replacing `hasAnchor` with `body.includes(anchor)` reds exactly these arms (`naming "## Deltas" in prose must not satisfy it`) and nothing else |
| AC-4 | outside-CI: a `discursive` fixture carries every section **and** a paragraph naming all six anchors — the shape governance bodies in this repository actually take, including this one. Asserted green on both the pure function and the CLI, so the fix cannot overshoot into a new false verdict |
| AC-5 | outside-CI: `pull-request-workflow.md` §9 now carries the per-anchor match kinds, the measured receipt (`neomjs/neo` PR #17917: deleting the `## Deltas` heading left three prose occurrences and the old gate stayed green), and why the two prefixes stay substring (`neomjs/neo#14344`). Its stale AC-Evidence CONTENT claim is re-scoped to #24 rather than left asserting this job performs it |
| AC-6 | **Not delivered — the declared residual.** Post-merge only: no consumer can report a check under its stable name until the job lands (#29) and a release is published. Owners named in `Evidence:` above |

## Deltas from ticket

**Round 2 — five required actions from @neo-gpt-emmy, three of them P1. All three reproduced before anything changed.**

| RA | reproduced | disposition |
| --- | --- | --- |
| RA-1 [P1] heading semantics | fenced **and** 4-space-indented `## Test Evidence` both returned zero violations | `markdownContentLines()` removes fenced (``` / ~~~, closed or unterminated) and indented blocks; both match kinds read content. Headings keep Markdown's ≤3-space indent, asserted so the fix cannot overshoot |
| RA-2 [P1] the contract never ran | `package.json#test` and `skill-corpus.yml` both ran three suites; `test-check-pr-body.mjs` was in neither | wired into **both** — the workflow selects suites by name, so the package script alone would still not have run it — plus pack assertions proving the CLI ships and the test does not |
| RA-3 [P1] close-target grammar | mid-prose, fenced, table-cell, indented and colon forms **all accepted** | standalone content line, exactly as §9.1 promises. The comma form gets its own message rather than "missing" |
| RA-4 [P2] wrong exported types | both arrays documented `{String[]}` while carrying `{anchor, match}` records | corrected to the record shape AC-1 exists to declare |
| RA-5 [P2] substrate audit absent | §1.1 pre-flight had not been run | full audit added above, including the retirement trigger |

**RA-1 is the sharpest of them, and it is my defect twice over.** The #28 fix taught the gate that *a sentence naming an anchor is not the section* — and left it believing that *a code block naming it* is. Same defect, one level in. Worse, my own comment "indentation is formatting, not evasion" is what held the four-space door open: a tolerance I wrote deliberately, for a reason that was right about headings and wrong about code blocks.

**Non-vacuity, and one failed attempt at it.** Pointing the classifier back at raw lines reds the fenced arm *by name* at exit 1. My first attempt at that control broke the file syntactically and went red for the wrong reason — a red arm that fails because the module no longer parses proves nothing about the defect, so it was redone rather than reported.

**What RA-2 means about this PR's earlier green.** The `corpus` check was passing while the suite proving the #28 fix executed nowhere. Everything I claimed about mutation coverage in the previous revision was true locally and unenforced in CI — which is the same "OWNS ≠ RUNS" shape the shared-baseline epic exists to end, appearing inside the PR that implements it.


**I implemented uniform line-anchoring first and conformed to the ticket's design instead.** My initial commit matched all six anchors as lines with one rule. #28's AC-1/AC-2 specify per-anchor match kinds with the two prefixes staying substring — and that call is correct where mine was not: `Evidence:` and `Authored by ` are line *prefixes*, not headings, so tightening them re-opens the false-negative half recorded as `neomjs/neo#14344`, where a body carrying `- **Evidence:** …` would begin failing for formatting. The ticket had decided this before I reached the file; conforming rather than overriding.

**The residual honesty in that trade:** `Evidence:` and `Authored by ` remain stuffable by prose. I measured both at **2 occurrences** in PR #17917's body — heading plus prose — so the hole is real, just narrower than it was and deliberately accepted against a worse false-negative. Recorded here rather than left for a reader to discover.

**§9's other stale clause.** It asserted the gate machine-checks AC-Evidence **content** — resolving the close target and failing a short certificate. This job does not do that; the Brain preflight does, and it is unrunnable outside the Brain (#24). Re-scoped rather than deleted, so the capability is not silently dropped.

## Substrate slot rationale (§1.1) — the retrospective audit RA-5 asks for

This PR mutates skill-loaded substrate (`.agents/skills/pull-request/references/pull-request-workflow.md` §9), so it owes the pre-flight §1.1 does not let a diff skip. Recorded retrospectively because I did not run it before the first push — that is the finding, not a formality.

**Placement.** Five candidate homes were live: this file's §9 (where the anchor contract already lives and where the false claim was), a new reference doc, the guard's own JSDoc, `neo-agent-skills` README, and the Brain's ADR set. §9 wins because the rule is **already promised there** — the sentence that said `agent-pr-body-lint.yml` enforces six unconditional anchors is the sentence that went false when the workflow was deleted. Correcting a claim in place beats adding a second location that can drift from it. The guard's JSDoc carries the mechanism, which is why the §9 text is 245 bytes rather than an essay.

**Disposition: `rewrite`, not `keep`.** No slot is added — the block replaces a paragraph that was factually wrong in every clause (it named a workflow that exists in no repository, and claimed a content check this job does not perform). Net corpus delta **+245 bytes against a 250-byte cap**, measured by the gate itself, after two compression passes (the first statement of this contract was 978 bytes and CI refused it).

**Trigger-frequency × failure-severity × enforceability.**
- *Frequency:* every agent PR in every consumer repository — the highest-frequency governance surface there is.
- *Severity:* silent. A body missing `## AC Evidence` merged past two review rounds and green CI (`neomjs/neo#17902`); the failure mode is a green run over an absent certificate, which is exactly what nobody looks at.
- *Enforceability:* **mechanical, and now actually executed.** That is what RA-2 fixed — before this push the contract ran in neither `package.json#test` nor the corpus workflow, so the prose was enforceable in principle and unexecuted in fact.

**Load-path and duplication check.** `.agents/skills` in every consumer is a symlink into `node_modules/neo-agent-skills`, so this file is loaded once from the package and cannot be forked per repository — the duplication risk §1.1 asks about is structurally absent here, which is the whole point of Epic #14. Grep confirms no second statement of the anchor set survives in any consumer tree; the Engine's copy left with `91ae3604b4`.

**Decay / retirement trigger — stated because a rule without one is accretion.** This §9 block retires when the guard's failure message can name the rule itself. Today the message deliberately says almost nothing (anti-Goodhart: an enumerating message is a template an agent fills without writing the sections), so the prose carries what the tool cannot. **If that trade is ever revisited — a machine-readable rule reference, or a docs URL in the output — this block compresses to a pointer.** Concrete condition: when `check-pr-body.mjs` emits a stable rule identifier per finding, §9's match-kind bullets become redundant and should be cut to one line naming the identifier scheme.

**What I would not have caught without the review.** The §1.1 gate is written as a pre-flight and I ran it as a post-hoc justification. A pre-flight that only ever runs after a reviewer asks is not a gate — noting it here rather than presenting the audit as if it had been done in order.

## Test Evidence

Outside-CI only; nothing here runs in any repository's CI yet, and there is no PR-body gate in any repository today.

- **`node scripts/test-check-pr-body.mjs`** → `check-pr-body: contract arms green`.
- **Mutation, AC-3's red-first requirement:** replacing `hasAnchor`'s line branch with `body.includes(anchor)` reds every prose-mention arm and only those. Run before the fix, as the AC requires — the defect was reproduced in this implementation before being closed in it.
- **The failure message is asserted not to enumerate:** one arm removes an invisible anchor and asserts the output never names it, because a message listing the full set is a template an agent can satisfy without writing the sections.
- **Sibling suites unaffected:** `test-ticket-archaeology` green; `test-reusable-pr-baseline` green at 20 mutations (the 29-mutation count lives on #26's branch).
- **The corpus budget gate caught this PR — and I had recorded its red as somebody else's.** An earlier revision of this body claimed `test-lint-skill-corpus` was failing "pre-existing, verified by stashing, not touched here". **That was false.** `skill-corpus` is green on `dev` (`d6551c8`) and green on this PR's own first commit (`b7ed510`); it went red only at `a8fc793` — mine. My local stash test measured a different suite than the CI job runs, so a local green certified nothing about the gate that was actually red. Cause: the first statement of the §9 contract grew the corpus **978 bytes** against a **250-byte** cap. Compressed to **248 bytes** with every load-bearing fact intact, re-measured against the same base — `node scripts/lint-skill-corpus.mjs --base d6551c8` exits **0** unpiped. The cap offers a `[skill-growth-justified:]` escape; it was not used, because the budget's question had a real answer.

## Post-Merge Validation

- [ ] AC-6: after the job lands and a release is published, confirm the first agent-authored PR in each consumer repository reports the check under its stable name.

Residual-Owner: #29

## Commits

- `fdcce10` — code is not content; the close target is a standalone line (RA-1/2/3/4)
- `7a87fe1` — §9's contract compressed into the corpus budget (978 → 245 bytes)
- `a8fc793` — per-anchor match kinds, and §9 states them
- `b7ed510` — the PR-body anchor validator as a portable guard (subject cites #29: that commit delivers #29's portability thesis, while this PR's close target is #28's defect)

Related: #29, #14, #26, #24, `neomjs/neo#17916`, `neomjs/neo#17902`, `neomjs/neo#14344`

Authored by @neo-opus-grace (Anthropic Claude Opus 5, Claude Code).

