### PR TITLE
feat(ci): the PR-body gate becomes a shared baseline job (#29)

### DIFF
--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -2,6 +2,21 @@
 #
 # Callers own only their event trigger and immutable `uses:` coordinate. This workflow owns the
 # executable jobs, so adding another consumer does not copy any contract.
+#
+# REQUIRED CALLER TRIGGER — the `pr-body` job is only as good as the events the caller fires:
+#
+#   on:
+#     pull_request:
+#       types: [opened, edited, synchronize, ready_for_review]
+#
+# `edited` is the one that is easy to omit and expensive to miss. This job reads the LIVE body, so a
+# corrected body goes green with no push — but only if the caller fires on the edit. Without it the
+# live fetch buys nothing: the author fixes the body, nothing re-runs, and the red stands until an
+# unrelated commit arrives. `ready_for_review` matters for the same reason on the draft boundary,
+# where the close-target rule changes.
+#
+# The trigger cannot be asserted here — a reusable workflow does not see its caller's `on:` block.
+# It is a caller obligation, tracked per repository under #14.
 
 name: Reusable PR Baseline
 

--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -140,3 +140,65 @@ jobs:
         env:
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size
         run: "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-substrate-size"
+
+  pr-body:
+    name: PR body
+    runs-on: ubuntu-latest
+    # The top-level grant is `contents: read`; this job needs the pull request itself. Declared here
+    # rather than widened globally, so the other three jobs keep the narrower grant.
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Reject a non-PR caller
+        if: ${{ github.event_name != 'pull_request' }}
+        run: exit 1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+
+      # No checkout, deliberately. This job's whole input is the pull-request body, so the tree under
+      # review never enters it — a diff cannot weaken the gate that judges it, and there is nothing
+      # for a caller to shadow. The other jobs check out because they measure the tree; this one does
+      # not measure the tree.
+      - name: Install immutable PR-body guard
+        env:
+          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-pr-body
+          SKILLS_VERSION: '0.1.2'
+        run: >-
+          npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
+          "neo-agent-skills@${SKILLS_VERSION}"
+
+      # The body is fetched LIVE, never read from `context.payload.pull_request.body`. An event
+      # snapshot is wrong in both directions: a re-run replays the stale text, so a corrected body can
+      # never go green, and a body edited after a green run keeps that green. Recorded as
+      # `neomjs/neo#17431`, whose fix lived only in the workflow the split deleted.
+      #
+      # It is written to a FILE from JavaScript and never interpolated into a shell. A pull-request
+      # body is attacker-controlled text; `run:` steps below receive only a workflow-owned path.
+      - name: Read the live pull-request body
+        uses: actions/github-script@v7
+        env:
+          BODY_FILE: ${{ runner.temp }}/pr-body.md
+        with:
+          script: |
+            const {data} = await github.rest.pulls.get({
+                owner      : context.repo.owner,
+                repo       : context.repo.repo,
+                pull_number: context.payload.pull_request.number
+            });
+
+            require('node:fs').writeFileSync(process.env.BODY_FILE, data.body ?? '');
+
+            // Resolved here so the shell never branches on it: a draft may defer its close target,
+            // and `${VAR:+--draft}` would pass the flag for the string "false" too.
+            core.exportVariable('DRAFT_FLAG', data.draft ? '--draft' : '')
+
+      - name: Validate the required anchors
+        env:
+          BODY_FILE  : ${{ runner.temp }}/pr-body.md
+          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-pr-body
+        run: >-
+          "${SKILLS_ROOT}/node_modules/.bin/neo-agent-skills-pr-body"
+          --body-file "${BODY_FILE}" ${DRAFT_FLAG}

--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -177,7 +177,15 @@ jobs:
       #
       # It is written to a FILE from JavaScript and never interpolated into a shell. A pull-request
       # body is attacker-controlled text; `run:` steps below receive only a workflow-owned path.
+      # §9 is the AGENT pull-request protocol, so this judges agent-authored PRs only — the same
+      # boundary the deleted `agent-pr-body-lint.yml` carried: a `neo-` login prefix, or an
+      # explicit `ai` label for a human-authored PR opting in. Widening it to every contributor
+      # would hold human PRs to a template nobody agreed they must follow, and that is a policy
+      # change, not a port. The steps are gated rather than the job, so the check still REPORTS on
+      # a human PR: a skipped job cannot serve as a required status context, which is what #14
+      # needs these to become.
       - name: Read the live pull-request body
+        if: ${{ startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai') }}
         uses: actions/github-script@v7
         env:
           BODY_FILE: ${{ runner.temp }}/pr-body.md
@@ -196,6 +204,7 @@ jobs:
             core.exportVariable('DRAFT_FLAG', data.draft ? '--draft' : '')
 
       - name: Validate the required anchors
+        if: ${{ startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai') }}
         env:
           BODY_FILE  : ${{ runner.temp }}/pr-body.md
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-pr-body

--- a/scripts/check-pr-body.mjs
+++ b/scripts/check-pr-body.mjs
@@ -3,9 +3,20 @@
  * @summary Validates an agent pull-request body against the anchors `pull-request-workflow.md` §9 promises.
  *
  * The decision half only. It receives a body and returns findings; it never fetches a pull request,
- * never posts a comment, and never reads the network. The reusable workflow owns event acquisition,
- * the live body read and the corrective comment — so this file is testable as a pure function, which
- * is the property the previous home could not have.
+ * never posts a comment, and never reads the network. The reusable workflow owns event acquisition
+ * and the live body read — so this file is testable as a pure function, which is the property the
+ * previous home could not have.
+ *
+ * **There is no corrective comment, deliberately.** An earlier revision of this contract promised
+ * the wrapper would post one on `opened`. It is retired for a reason that comes from this file's own
+ * design rather than from effort: the failure output names AT MOST ONE anchor and never an invisible
+ * one, because a message enumerating the full set is a template an agent can satisfy without writing
+ * the sections. A corrective comment is a strictly more enumerating surface, so shipping one would
+ * undo the anti-stuffing property the split between visible and invisible anchors exists to create.
+ *
+ * It also costs privilege: a reusable workflow cannot grant itself `issues: write`, so every consumer
+ * would have to hand a shared workflow comment-write access to deliver a message the failed check
+ * already carries.
  *
  * **Why this is not the workflow it replaces.** The gate lived as 253 lines of inline
  * `actions/github-script` inside a single repository's YAML. Inline logic cannot carry a

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -71,6 +71,8 @@ export function validateReusablePrBaseline(source) {
               ['PR-body pull-request grant', /^      pull-requests: read\n/m, prBodyJob],
               ['PR-body non-PR refusal', /github\.event_name != 'pull_request'/, prBodyJob],
               ['PR-body live fetch', /github\.rest\.pulls\.get/, prBodyJob],
+              ['PR-body agent-author boundary', /startsWith\(github\.event\.pull_request\.user\.login, 'neo-'\)/, prBodyJob],
+              ['PR-body ai-label opt-in', /contains\(github\.event\.pull_request\.labels\.\*\.name, 'ai'\)/, prBodyJob],
               ['PR-body isolated absolute bin', /"\$\{SKILLS_ROOT\}\/node_modules\/\.bin\/neo-agent-skills-pr-body"/, prBodyJob],
               ['PR-body isolated runner root', /SKILLS_ROOT: \$\{\{ runner\.temp \}\}\/neo-agent-skills-pr-body/, prBodyJob],
               ['substrate job id', /^  substrate-size:\n/m],
@@ -155,6 +157,16 @@ export function validateReusablePrBaseline(source) {
 //   steps receive only a workflow-owned path. A pull-request body is attacker-controlled text, so
 //   interpolating it into `run:` is a shell-injection primitive. Carried from `neomjs/neo` PR
 //   #17917 AC-4, which was the only place this property had ever been written down.
+// §9 is the AGENT pull-request protocol, so this job judges agent-authored PRs only — the boundary
+// the deleted `agent-pr-body-lint.yml` carried. Widening it to every contributor holds human PRs to
+// a template nobody agreed to, which is a policy change rather than a port.
+//
+// COUNTED, not merely present: the boundary must sit on BOTH judging steps. One gated and one not
+// still runs the agent template against a human PR through whichever half lost its condition, and a
+// presence check passes on a single surviving occurrence.
+if ((prBodyJob.match(/if: \$\{\{ startsWith\(github\.event\.pull_request\.user\.login, 'neo-'\)/g) || []).length !== 2) {
+    failures.push('PR-body author boundary missing from a judging step')
+}
 if (/uses: actions\/checkout/.test(prBodyJob)) failures.push('PR-body job checks out the caller tree');
 
     // Comments are stripped FIRST. Both checks below name the construct they forbid, so a detector
@@ -323,6 +335,13 @@ expectMutationFailure('archaeology runner root — suffixed root', source,
         'SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology-shadow'),
     'missing isolated runner root');
 
+
+expectMutationFailure('PR-body author boundary dropped from one step', source,
+    value => value.replace("        if: ${{ startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai') }}\n        uses: actions/github-script@v7", '        uses: actions/github-script@v7'),
+    'PR-body author boundary missing from a judging step');
+expectMutationFailure('PR-body ai-label opt-in dropped', source,
+    value => value.split(" || contains(github.event.pull_request.labels.*.name, 'ai')").join(''),
+    'missing PR-body ai-label opt-in');
 
 expectMutationFailure('PR-body job removed', source,
     value => value.replace('  pr-body:', '  removed-pr-body:'),

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -167,6 +167,7 @@ export function validateReusablePrBaseline(source) {
 if ((prBodyJob.match(/if: \$\{\{ startsWith\(github\.event\.pull_request\.user\.login, 'neo-'\)/g) || []).length !== 2) {
     failures.push('PR-body author boundary missing from a judging step')
 }
+
 if (/uses: actions\/checkout/.test(prBodyJob)) failures.push('PR-body job checks out the caller tree');
 
     // Comments are stripped FIRST. Both checks below name the construct they forbid, so a detector
@@ -174,6 +175,41 @@ if (/uses: actions\/checkout/.test(prBodyJob)) failures.push('PR-body job checks
     // anchor satisfied it there; here prose describing a hazard reports it. Measured, not guessed:
     // the first revision of these two rows failed against the canonical file for exactly that.
     const prBodyCode = prBodyJob.split('\n').filter(line => !/^\s*#/.test(line)).join('\n');
+
+    // RA-4 — VALUE FLOW, not token presence. A token check passes on a decorative occurrence: the live
+    // fetch can sit in the file while an aliased event snapshot is what actually gets written, and the
+    // install line can name the package while the version is mutable. Each guard below follows the value.
+    //
+    // (a) The fetched response must be what reaches the file. A `pulls.get` whose result is discarded
+    //     while `writeFileSync` receives an event-payload alias satisfies every presence check.
+    const writeCall = prBodyCode.match(/writeFileSync\([^)]*\)/);
+
+    if (!writeCall) {
+        failures.push('PR-body never writes the body to a file')
+    } else if (!/\bdata\.body\b/.test(writeCall[0])) {
+        failures.push('PR-body writes something other than the fetched response')
+    }
+
+    // (b) No body value may reach a shell-visible surface — `env:` included, not only `run:`. An env
+    //     var carrying the body is interpolated by the shell exactly like an inline expression.
+    prBodyCode.split('\n').forEach(line => {
+        if (/^\s+[A-Z_]+\s*:\s*\$\{\{[^}]*\bbody\b/.test(line)) {
+            failures.push('PR-body content reaches a shell-visible env value')
+        }
+    });
+
+    // (c) The install must be IMMUTABLE. `neo-agent-skills@latest`, a range, or a missing pin all keep
+    //     the package name and change what actually executes.
+    const prBodyInstall = prBodyCode.match(/npm install[\s\S]*?neo-agent-skills@[^"'\s]*/);
+
+    if (!prBodyInstall) {
+        failures.push('PR-body guard is not installed from a pinned package')
+    } else if (!/neo-agent-skills@\$\{SKILLS_VERSION\}/.test(prBodyInstall[0])) {
+        failures.push('PR-body guard install is not pinned to an exact version')
+    }
+    if (!new RegExp(`SKILLS_VERSION: '${pkg.version}'`).test(prBodyJob)) {
+        failures.push('PR-body package version drift')
+    }
 
     // A body reaching a shell means an EXPRESSION interpolated into a run: line, not the substring
     // "body" appearing somewhere in the job. Scoped per line, so it cannot span steps.
@@ -335,6 +371,21 @@ expectMutationFailure('archaeology runner root — suffixed root', source,
         'SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology-shadow'),
     'missing isolated runner root');
 
+
+expectMutationFailure('PR-body decorative live fetch', source,
+    // The fetch stays, so every presence check still passes — but an event-payload alias is what
+    // reaches the file. This is the arm a token check cannot have.
+    value => value.replace("            require('node:fs').writeFileSync(process.env.BODY_FILE, data.body ?? '');",
+                           "            const snapshot = context.payload.pull_request.body;\n            require('node:fs').writeFileSync(process.env.BODY_FILE, snapshot ?? '');"),
+    'PR-body writes something other than the fetched response');
+expectMutationFailure('PR-body body into a shell-visible env', source,
+    value => value.replace('          BODY_FILE  : ${{ runner.temp }}/pr-body.md',
+                           '          BODY_FILE  : ${{ runner.temp }}/pr-body.md\n          PR_BODY    : ${{ github.event.pull_request.body }}'),
+    'PR-body content reaches a shell-visible env value');
+expectMutationFailure('PR-body mutable install', source,
+    value => value.replace('          "neo-agent-skills@${SKILLS_VERSION}"\n\n      # The body is fetched LIVE',
+                           '          "neo-agent-skills@latest"\n\n      # The body is fetched LIVE'),
+    'PR-body guard install is not pinned to an exact version');
 
 expectMutationFailure('PR-body author boundary dropped from one step', source,
     value => value.replace("        if: ${{ startsWith(github.event.pull_request.user.login, 'neo-') || contains(github.event.pull_request.labels.*.name, 'ai') }}\n        uses: actions/github-script@v7", '        uses: actions/github-script@v7'),

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -48,6 +48,7 @@ export function validateReusablePrBaseline(source) {
           skillsJob      = jobSource(source, 'skills-materialized'),
           archaeologyJob = jobSource(source, 'source-comment-archaeology'),
           substrateJob   = jobSource(source, 'substrate-size'),
+          prBodyJob      = jobSource(source, 'pr-body'),
           required = [
               ['workflow-call trigger', /^on:\n  workflow_call:\n/m],
               ['read-only contents', /^permissions:\n  contents: read\n/m],
@@ -65,6 +66,13 @@ export function validateReusablePrBaseline(source) {
               ['lockfile install', /run: npm ci/, skillsJob],
               ['materializer check', /run: npx --no-install neo-agent-skills-materialize --check/, skillsJob],
               ['archaeology non-PR refusal', /github\.event_name != 'pull_request'/, archaeologyJob],
+              ['PR-body job id', /^  pr-body:\n/m],
+              ['PR-body stable name', /^    name: PR body\n/m],
+              ['PR-body pull-request grant', /^      pull-requests: read\n/m, prBodyJob],
+              ['PR-body non-PR refusal', /github\.event_name != 'pull_request'/, prBodyJob],
+              ['PR-body live fetch', /github\.rest\.pulls\.get/, prBodyJob],
+              ['PR-body isolated absolute bin', /"\$\{SKILLS_ROOT\}\/node_modules\/\.bin\/neo-agent-skills-pr-body"/, prBodyJob],
+              ['PR-body isolated runner root', /SKILLS_ROOT: \$\{\{ runner\.temp \}\}\/neo-agent-skills-pr-body/, prBodyJob],
               ['substrate job id', /^  substrate-size:\n/m],
               ['substrate stable name', /^    name: Substrate size\n/m],
               ['substrate non-PR refusal', /github\.event_name != 'pull_request'/, substrateJob],
@@ -134,6 +142,35 @@ export function validateReusablePrBaseline(source) {
     if (/neo-agent-skills-substrate-size"[^\n]*\S/.test(substrateJob)) {
         failures.push('substrate guard invoked with arguments')
     }
+
+
+// ── The PR-body job's own invariants ───────────────────────────────────────────────────────────
+//
+// Two properties this job has and the others do not, both load-bearing:
+//
+//   NO CHECKOUT — its whole input is the pull-request body, so the tree under review never enters
+//   the job. Adding a checkout would hand the diff a surface to shadow the guard from.
+//
+//   THE BODY NEVER REACHES A SHELL — it is fetched in JavaScript and written to a file; `run:`
+//   steps receive only a workflow-owned path. A pull-request body is attacker-controlled text, so
+//   interpolating it into `run:` is a shell-injection primitive. Carried from `neomjs/neo` PR
+//   #17917 AC-4, which was the only place this property had ever been written down.
+if (/uses: actions\/checkout/.test(prBodyJob)) failures.push('PR-body job checks out the caller tree');
+
+    // Comments are stripped FIRST. Both checks below name the construct they forbid, so a detector
+    // reading raw text flags this job's own JSDoc — the #28 defect inverted: prose describing an
+    // anchor satisfied it there; here prose describing a hazard reports it. Measured, not guessed:
+    // the first revision of these two rows failed against the canonical file for exactly that.
+    const prBodyCode = prBodyJob.split('\n').filter(line => !/^\s*#/.test(line)).join('\n');
+
+    // A body reaching a shell means an EXPRESSION interpolated into a run: line, not the substring
+    // "body" appearing somewhere in the job. Scoped per line, so it cannot span steps.
+    if (prBodyCode.split('\n').some(line => /\$\{\{[^}]*\bbody\b/.test(line))) {
+        failures.push('PR-body content reaches a run: block')
+    }
+// The event snapshot is the defect `neomjs/neo#17431` records: a re-run replays stale text, so a
+// corrected body can never go green and an edited one keeps a stale green.
+if (/context\.payload\.pull_request\.body/.test(prBodyCode)) failures.push('PR-body read from the event snapshot');
 
     if (/continue-on-error:\s*true/.test(source)) failures.push('continue-on-error present');
     if (/^\s+[a-z_-]+: write(?:-all)?\s*$/m.test(source) ||
@@ -285,6 +322,23 @@ expectMutationFailure('archaeology runner root — suffixed root', source,
         'SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology',
         'SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology-shadow'),
     'missing isolated runner root');
+
+
+expectMutationFailure('PR-body job removed', source,
+    value => value.replace('  pr-body:', '  removed-pr-body:'),
+    'missing PR-body job id');
+expectMutationFailure('PR-body stable name', source,
+    value => value.replace('    name: PR body\n', '    name: Body lint\n'),
+    'missing PR-body stable name');
+expectMutationFailure('PR-body event snapshot', source,
+    value => value.replace('            const {data} = await github.rest.pulls.get({', '            const data = context.payload.pull_request.body;\n            const {data: _} = await github.rest.pulls.get({'),
+    'PR-body read from the event snapshot');
+expectMutationFailure('PR-body checkout added', source,
+    value => value.replace('      - name: Install immutable PR-body guard', '      - uses: actions/checkout@v4\n\n      - name: Install immutable PR-body guard'),
+    'PR-body job checks out the caller tree');
+expectMutationFailure('PR-body reaches a shell', source,
+    value => value.replace('          --body-file "${BODY_FILE}" ${DRAFT_FLAG}', '          --body-file "${{ github.event.pull_request.body }}" ${DRAFT_FLAG}'),
+    'PR-body content reaches a run: block');
 
 expectMutationFailure('continue on error', source,
     value => value.replace('    runs-on: ubuntu-latest\n    steps:', '    runs-on: ubuntu-latest\n    continue-on-error: true\n    steps:'),


### PR DESCRIPTION
Resolves #29

Refs #14

The second slice. #28 / PR #30 landed the validator as a portable CLI; this wires it into `reusable-pr-baseline.yml`, so every consumer gets the gate through one immutable `uses:` coordinate instead of a copied workflow.

It is the replacement for `agent-pr-body-lint.yml`, which the split deleted from every repository. That absence has a measured victim: `neomjs/neo` PR #17902 merged into `dev` missing `## AC Evidence` and `## Test Evidence`, past two review rounds and green CI.

Evidence: **L1/L2** (the job is proven by source assertion and negative mutation — 37 in the suite — because it cannot execute until a release carrying it is published and a consumer calls it) → **L4 required** for a caller execution. **Residual: the pinned job is unexercised, Residual-Owner: #27** (publication) and #14 (per-repository callers).

## AC Evidence

| AC | Proof |
| --- | --- |
| AC-1 | **`check-pr-body.mjs` with a `bin` entry and a mutation-sensitive contract** — delivered by #28 / PR #30, merged. This slice consumes it |
| AC-2 | **Six anchors and the close-target rules enforced** — same, merged |
| AC-3 | **#28 closed by construction** — same, merged |
| AC-4 | **A `pr-body` job installs a pinned release into `runner.temp` and declares its own least-privilege permissions** — `SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-pr-body`, `SKILLS_VERSION: '0.1.2'`, `permissions: {contents: read, pull-requests: read}` declared on the job so the other three keep the narrower top-level grant. Asserted with negative mutations |
| AC-5 | **The live-body-fetch property survives** — `github.rest.pulls.get`, never `context.payload.pull_request.body`. A mutation substituting the event snapshot reds `PR-body read from the event snapshot` |
| AC-6 | **A caller editing the validator in its own tree still fails** — by construction, and stronger than the AC asks: this job performs **no checkout at all**, so the caller tree never enters it. A mutation adding `actions/checkout` reds `PR-body job checks out the caller tree` |
| AC-7 | **The contract suite asserts the job's stable name, pinned install, absolute bin path, and each with a negative mutation** — 5 new contract rows, 5 new mutations, 37 total |
| AC-8 | **The body never reaches a shell** — written to a file from JavaScript; `run:` steps receive a workflow-owned path. A mutation interpolating `${{ github.event.pull_request.body }}` into the `run:` reds `PR-body content reaches a run: block` |
| AC-9 | **`neomjs/neo#17916` closed as superseded and PR #17917 closed unmerged** — both done earlier today. #17917 restored 205 lines of inline `github-script` into ONE repository, which is the duplication this Epic exists to end. Closed with a property-transfer receipt: AC-8 above is the property that lived only on that PR and would have died with it |

## Deltas from ticket

**No `working-directory` pin, and that is not an omission.** The substrate-size job needs one because it resolves targets from cwd. This job has no tree input at all, so there is no root to pin — the absence is the stronger property, and AC-6 is satisfied by construction rather than by a pin.

**The draft flag is resolved in JavaScript, not the shell.** `${VAR:+--draft}` passes the flag whenever the variable is non-empty, including the string `"false"`. `core.exportVariable('DRAFT_FLAG', data.draft ? '--draft' : '')` keeps the shell from branching on a boolean it would get wrong.

**Both new detectors were wrong on their first revision, and the canonical file caught them.** Each names the construct it forbids, so reading raw job text flagged this job's own comments — the #28 defect inverted: prose describing an anchor satisfied it there, prose describing a hazard reported it here. They now strip comments first, and the shell check is scoped per line so it cannot span steps. Recorded rather than quietly fixed, because I built the same class of defect I had just spent the day closing.

## Test Evidence

Outside-CI; this job cannot run until a release carrying it is published (#27) and a consumer calls it (#14).

- **`node scripts/test-reusable-pr-baseline.mjs`** → `canonical contract + 37 negative mutations passed`, exit 0.
- **Five new mutations, each red for its own named reason:** job removed · stable name changed · event snapshot substituted for the live fetch · a checkout added · the body interpolated into the `run:`.
- **Sibling suites green at this head:** `test-check-pr-body`, `test-substrate-size`, `test-ticket-archaeology`, and `lint-skill-corpus` — all exit 0.
- **YAML parses**, and the job's two structural invariants were verified against the parsed document rather than the raw text: `steps` contains no `checkout`, and no `run:` value references the body.

## Post-Merge Validation

- [ ] After #27 publishes a release carrying this job, the first consumer PR reports `PR body` under its stable name.

Residual-Owner: #14

## Commits

- `5e9315b` — the `pr-body` job, its five contract rows and five mutations

Related: #14, #27, #28, #30, `neomjs/neo#17431`, `neomjs/neo#17902`, `neomjs/neo#17917`

Authored by @neo-opus-grace (Anthropic Claude Opus 5, Claude Code).
