### PR TITLE
fix(ci): the reusable baseline pins the version that exists (#27)

### DIFF
--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install immutable archaeology guard
         env:
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology
-          SKILLS_VERSION: '0.1.2'
+          SKILLS_VERSION: '0.1.3'
         run: >-
           npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
           "neo-agent-skills@${SKILLS_VERSION}"
@@ -135,7 +135,7 @@ jobs:
       - name: Install immutable substrate guard
         env:
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size
-          SKILLS_VERSION: '0.1.2'
+          SKILLS_VERSION: '0.1.3'
         run: >-
           npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
           "neo-agent-skills@${SKILLS_VERSION}"
@@ -180,7 +180,7 @@ jobs:
       - name: Install immutable PR-body guard
         env:
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-pr-body
-          SKILLS_VERSION: '0.1.2'
+          SKILLS_VERSION: '0.1.3'
         run: >-
           npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
           "neo-agent-skills@${SKILLS_VERSION}"

--- a/scripts/test-reusable-pr-baseline.mjs
+++ b/scripts/test-reusable-pr-baseline.mjs
@@ -321,7 +321,7 @@ expectMutationFailure('substrate runner isolation', source,
     'missing substrate isolated runner root');
 expectMutationFailure('substrate package version', source,
     value => value.replace(
-        "          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size\n          SKILLS_VERSION: '0.1.2'",
+        `          SKILLS_ROOT: \${{ runner.temp }}/neo-agent-skills-substrate-size\n          SKILLS_VERSION: '${pkg.version}'`,
         "          SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size\n          SKILLS_VERSION: 'latest'"),
     'substrate package version drift');
 // Anchored on the STEP NAME rather than the comment that follows it. The archaeology job carries a


### PR DESCRIPTION
Resolves #27

`dev` has been red since `27ad8959` (the `v0.1.3` cut, 2026-09-01T21:22:20Z). Three lines fix it, and the fix the ticket prescribes is no longer the right one.

## What was wrong

`test-reusable-pr-baseline.mjs` asserts `SKILLS_VERSION === pkg.version`. `package.json` moved to `0.1.3`; `reusable-pr-baseline.yml` still pinned `'0.1.2'` at `:99`, `:138`, `:183` — so the cut tripped all three drift assertions at once:

```
AssertionError: canonical reusable workflow violates its own contract
+ 'package version drift', 'substrate package version drift', 'PR-body package version drift'
```

## Why the ticket's fix is obsolete, not pending

#27 (2026-08-31) concluded that lowering the pin reddens the contract test while leaving it reddens the install, so *"the only exit that satisfies both is publishing `0.1.2` — that is an operator act."*

Measured at head: npm carries `0.1.0`, `0.1.1`, `0.1.3`. **`0.1.2` was skipped entirely**, and `0.1.3` published at `2026-09-01T21:27:20Z` — five minutes *after* the break. There is no operator act left to wait for. The exact-pin design is correct and untouched; the pin simply has to name a version that exists.

## The second defect, which the first was hiding

Fixing the pins turned the drift failures into a different one:

```
AssertionError: substrate package version: fixture mutation changed nothing
```

`test-reusable-pr-baseline.mjs:324` hardcoded `SKILLS_VERSION: '0.1.2'` in its mutation fixture, while the `package version` sibling at `:289` interpolates `` `SKILLS_VERSION: '${pkg.version}'` ``. So the substrate mutation silently stopped mutating anything the moment the version moved — a control that can no longer fail.

**The codebase caught its own rot.** `expectMutationFailure`'s `assert.notEqual(mutated, source)` exists precisely so a fixture cannot pass by doing nothing, and it is what fired. The fixture now interpolates like its sibling, so it cannot rot on the next bump.

## Evidence

Evidence: L2 (the repo's own contract + mutation suite, run locally at head and required in CI) → L2 required (both ACs are static contract). Residual: none.

| AC | evidence |
|---|---|
| The pin resolves on npm | `npm view neo-agent-skills versions` → `0.1.0, 0.1.1, 0.1.3`; the pin now names `0.1.3` |
| The contract test is green | `node scripts/test-reusable-pr-baseline.mjs` → exit 0, *"canonical contract + 42 negative mutations passed"* |
| The mutation control still discriminates | It failed **red-first** with `fixture mutation changed nothing` before the fixture was fixed — the control proved it can fail, then passed |
| No behaviour change to the workflow | Only the three `SKILLS_VERSION` values differ; jobs, triggers, permissions and install lines are untouched |

## Test Evidence

- `node scripts/test-reusable-pr-baseline.mjs` — exit 0, canonical contract + 42 negative mutations.
- `npm run lint` — exit 0, *"37 skills, coherent with the manifest, within budget, document reach canonical."*
- `npm test` — **24/25, both arms.** The one failure (*"a clean non-Neo consumer resolves projected document references"*, dangling `.claude/skills/*` links whose `node_modules` target is gone) reproduces identically on clean `origin/dev` with this branch stashed, and CI was green on `aae27168` immediately before the cut. Local-environment, measured on both arms rather than assumed — not attributable to this diff.

## Why this is worth a PR tonight

#27 gates neo-agent-skills#14, which gates neomjs/neo#17783, which is why `neomjs/neo` wires no caller to this reusable workflow. Net effect measured on `neomjs/neo` `dev`: `AGENTS.md` is **24,574 B against a 24,576 B limit — two bytes of headroom with nothing in CI watching**, because the `substrate-size` job that would watch it lives in a workflow no repo can call while the pin is unresolvable.

## Out of scope

- neomjs/neo#17783 — the `neomjs/neo` caller. @neo-gpt's, and it stays his.
- neo-agent-skills#14 — the governance-unification epic above this.
- neomjs/neo#17175's `@`-import budgeting half (AC-1/AC-2), still unrun.
- The `0.1.2` version number itself. It is skipped, not reserved; nothing here republishes it.

---

⚖️ **Ada** · `@neo-opus-ada` · Claude Opus 5 · Claude Code · session 19b7841a-2252-438d-950f-5635b48f0cb8
