### PR TITLE
feat(ticket-create): the epic-layer outcome-authority sweep (#9)

### DIFF
--- a/.agents/skills/epic-create/references/epic-create-workflow.md
+++ b/.agents/skills/epic-create/references/epic-create-workflow.md
@@ -47,7 +47,7 @@ Each sub the decomposition creates MUST be a **leaf that a single PR can FULLY d
 
 ## Procedure
 
-1. **Confirm Epic-shape.** The work needs ≥2 coordinated subs. A single bounded artifact (≈1 PR's worth) is a standalone ticket (`ticket-create`), not an Epic.
+1. **Confirm Epic-shape, then run the epic-layer sweep.** The work needs ≥2 coordinated subs; a single bounded artifact (≈1 PR's worth) is a standalone ticket (`ticket-create`), not an Epic. Then run `ticket-create-workflow.md` §1a arm `(v)` before authoring — read every open `label:epic` issue and compare **terminal predicates**, not titles. An outcome authority does not churn, so §1a's recency and title axes are both structurally blind to it, and competing roots split sub-attachment, review attention and closure authority until someone folds them.
 2. **Run the Agent OS structure map.** Before authoring the body, run `npm run --silent ai:structure-map -- --files --loc`; use it for Agent OS / architecture placement claims or record N/A.
 3. **Graduation gate (if from a Discussion).** High-blast Epics require the §6.2 family-keyed quorum + the §5.1 divergence matrix in the source Discussion before filing (per `ideation-sandbox-workflow.md` + `ideation-sandbox/audits/double-diamond-divergence-guard.md`). Carry the `Signal Ledger` / dissent / liveness / criteria-mapping sections into the body.
 4. **Author the body** = problem-scope + intended-solution (+ ledger if graduated). NO ACs, NO sub-list.

--- a/.agents/skills/epic-create/references/epic-create-workflow.md
+++ b/.agents/skills/epic-create/references/epic-create-workflow.md
@@ -47,7 +47,7 @@ Each sub the decomposition creates MUST be a **leaf that a single PR can FULLY d
 
 ## Procedure
 
-1. **Confirm Epic-shape, then run the epic-layer sweep.** The work needs ≥2 coordinated subs; a single bounded artifact (≈1 PR's worth) is a standalone ticket (`ticket-create`), not an Epic. Then run `ticket-create-workflow.md` §1a arm `(v)` before authoring — read every open `label:epic` issue and compare **terminal predicates**, not titles. An outcome authority does not churn, so §1a's recency and title axes are both structurally blind to it, and competing roots split sub-attachment, review attention and closure authority until someone folds them.
+1. **Confirm Epic-shape, then run §1a arm `(v)`.** The work needs ≥2 coordinated subs; a single bounded artifact (≈1 PR's worth) is a standalone ticket (`ticket-create`), not an Epic. Arm `(v)` — the epic-layer sweep, mandatory before authoring — reads every open `label:epic` issue and compares **terminal predicates**, not titles.
 2. **Run the Agent OS structure map.** Before authoring the body, run `npm run --silent ai:structure-map -- --files --loc`; use it for Agent OS / architecture placement claims or record N/A.
 3. **Graduation gate (if from a Discussion).** High-blast Epics require the §6.2 family-keyed quorum + the §5.1 divergence matrix in the source Discussion before filing (per `ideation-sandbox-workflow.md` + `ideation-sandbox/audits/double-diamond-divergence-guard.md`). Carry the `Signal Ledger` / dissent / liveness / criteria-mapping sections into the body.
 4. **Author the body** = problem-scope + intended-solution (+ ledger if graduated). NO ACs, NO sub-list.

--- a/.agents/skills/epic-create/references/epic-create-workflow.md
+++ b/.agents/skills/epic-create/references/epic-create-workflow.md
@@ -16,6 +16,7 @@ An Epic body is **problem-scope + intended-solution** — the durable "why + wha
 
 Epic creation uses the same importance order as ticket and PR review: the problem/premise and intended placement dominate the verdict. Sub AC detail belongs in leaf tickets; an Epic with exhaustive sub mechanics but a weak premise or wrong owning substrate is not ready.
 
+0. **`Terminal predicate:` — one line, the body's first line, mandatory.** The state of the world this Epic declares finished, in the outcome's own vocabulary: *what sentence does closing this Epic let us write?* This is not a summary of the problem — it is the condition that ends it. It exists to be **addressable**: `ticket-create` §1a arm `(v)` compares predicates, and with this field a filer compares N one-line fields instead of reading N full bodies. A gate priced at the second number is a gate that gets skipped, and a skipped gate still gets its attestation line written.
 1. **Problem scope** — the friction / antipattern-cluster / goal, with empirical anchors. State why this needs an Epic (multi-sub coordination) rather than a single ticket.
 2. **Intended solution shape** — the architectural direction (the "what-shape"), NOT the per-sub task breakdown. Enough that a reader knows the convergent shape the subs will serve.
 3. **(If Discussion-graduated) the §6.6 Signal Ledger** — the graduation consensus record (family-keyed quorum, unresolved dissent / liveness, criteria-mapping) per `ideation-sandbox-workflow.md §6`. This is the one structured matrix that belongs in an Epic body, because it records the graduation event, not the sub-plan.
@@ -47,10 +48,10 @@ Each sub the decomposition creates MUST be a **leaf that a single PR can FULLY d
 
 ## Procedure
 
-1. **Confirm Epic-shape, then run §1a arm `(v)`.** The work needs ≥2 coordinated subs; a single bounded artifact (≈1 PR's worth) is a standalone ticket (`ticket-create`), not an Epic. Arm `(v)` — the epic-layer sweep, mandatory before authoring — reads every open `label:epic` issue and compares **terminal predicates**, not titles.
+1. **Confirm Epic-shape, then run §1a arm `(v)`.** The work needs ≥2 coordinated subs; a single bounded artifact (≈1 PR's worth) is a standalone ticket (`ticket-create`), not an Epic. Arm `(v)` — the epic-layer sweep, mandatory before authoring — compares **terminal predicates**, not titles, reading every open `label:epic` issue's `Terminal predicate:` line and only the bodies an outcome-overlap query ranks.
 2. **Run the Agent OS structure map.** Before authoring the body, run `npm run --silent ai:structure-map -- --files --loc`; use it for Agent OS / architecture placement claims or record N/A.
 3. **Graduation gate (if from a Discussion).** High-blast Epics require the §6.2 family-keyed quorum + the §5.1 divergence matrix in the source Discussion before filing (per `ideation-sandbox-workflow.md` + `ideation-sandbox/audits/double-diamond-divergence-guard.md`). Carry the `Signal Ledger` / dissent / liveness / criteria-mapping sections into the body.
-4. **Author the body** = problem-scope + intended-solution (+ ledger if graduated). NO ACs, NO sub-list.
+4. **Author the body** = the `Terminal predicate:` line, then problem-scope + intended-solution (+ ledger if graduated). NO ACs, NO sub-list.
 5. **Label `epic`** + apply title hygiene (per `ticket-create`).
 6. **Create subs separately** (via `ticket-create` — each with its own ACs + Contract Ledger) and **link each via `update_issue_relationship`** (parent = the Epic). Add subs incrementally as decomposition clarifies; that governs Epic life. Goal-scoping graduation is stricter: full v1 leaves are filed/native-linked, while the Epic body stays sub-list-free.
 7. **Verify** (pre-flight, before `create_issue`):

--- a/.agents/skills/ticket-create/references/decision-substrate-sweeps.md
+++ b/.agents/skills/ticket-create/references/decision-substrate-sweeps.md
@@ -44,7 +44,14 @@ Fires only on **epic-labeled** filings.
 gh issue list --repo <r> --label epic --state open --json number,title
 ```
 
-Read **every** row — there are few — plus one semantic outcome-overlap query. Compare **terminal predicates**, not titles: *what state of the world does this Epic declare finished?* Two Epics that finish the same sentence are one Epic, however differently they open.
+Compare **terminal predicates**, not titles: *what state of the world does this Epic declare finished?* Two Epics that finish the same sentence are one Epic, however differently they open.
+
+**Read every row, but read one line of it.** `epic-create` requires each Epic body to open with a `Terminal predicate:` line precisely so this sweep is priced in lines, not bodies. Two stages, and the second is bounded by the first:
+
+1. **Predicate scan (every row).** Read each open epic's `Terminal predicate:` line. Cheap enough to be exhaustive, which is the only reason "every" is honest here.
+2. **Body read (the ranked few).** For rows predating the field, or whose predicate is close enough to yours to be arguable, run the semantic outcome-overlap query and read only the bodies it ranks. Retrieval surfaces the candidates; **only a reader can rule** — that is the judgement the arm exists to force, and it is not the part that was expensive.
+
+> **Population anchor, measured 2026-09-02 — do not trust this as a present-tense fact, re-run it.** Open `label:epic`: `neomjs/neo` **29**, `neo-agent-brain` **34**, `neo-agent-institution` 6, `neo-agent-skills` 1; the first five `neomjs/neo` bodies run 4,936–12,575 characters. An unstaged all-bodies read is therefore ~290k characters in one repo — the cost that mutes a gate within a week. A rule that embeds a population as an **adjective** ("there are few") carries a fact that decays silently while its prose stays confident; state the number with its date, or state the query.
 
 An outcome authority does not churn, so it sits permanently outside `(i)`'s window and its title speaks the outcome's vocabulary rather than a newcomer's — both artifact axes miss it, for different reasons. The cost is topology: competing roots split sub-attachment, review attention and closure authority until someone folds them.
 

--- a/.agents/skills/ticket-create/references/decision-substrate-sweeps.md
+++ b/.agents/skills/ticket-create/references/decision-substrate-sweeps.md
@@ -46,7 +46,7 @@ gh issue list --repo <r> --label epic --state open --json number,title
 
 Read **every** row — there are few — plus one semantic outcome-overlap query. Compare **terminal predicates**, not titles: *what state of the world does this Epic declare finished?* Two Epics that finish the same sentence are one Epic, however differently they open.
 
-**Why `(i)` cannot reach these.** An outcome authority is defined by not churning: it is filed once, then supervises for weeks. That places it permanently outside a latest-20 window, so the recency axis is not merely unlucky here — it is **structurally** blind. And its title is written in the vocabulary of the outcome (*"An external plane cannot recover itself…"*), which shares no keywords with a newcomer's framing of the same outcome, so title search misses it too. Both existing artifact axes fail on the same filing for different reasons.
+**Why `(i)` cannot reach these.** An outcome authority is defined by not churning — filed once, then supervising for weeks — so it sits permanently outside a latest-20 window: the recency axis is **structurally** blind here, not unlucky. Its title speaks the outcome's vocabulary (*"An external plane cannot recover itself…"*), sharing no keywords with a newcomer's framing of that same outcome, so title search misses it too.
 
 **Why the cost is topology, not tidiness.** A duplicate leaf is one closure. Competing Epic roots split *sub-attachment, review attention and closure authority* until someone reconciles them — and each sub filed under the wrong root deepens the split.
 

--- a/.agents/skills/ticket-create/references/decision-substrate-sweeps.md
+++ b/.agents/skills/ticket-create/references/decision-substrate-sweeps.md
@@ -46,11 +46,9 @@ gh issue list --repo <r> --label epic --state open --json number,title
 
 Read **every** row — there are few — plus one semantic outcome-overlap query. Compare **terminal predicates**, not titles: *what state of the world does this Epic declare finished?* Two Epics that finish the same sentence are one Epic, however differently they open.
 
-**Why `(i)` cannot reach these.** An outcome authority is defined by not churning — filed once, then supervising for weeks — so it sits permanently outside a latest-20 window: the recency axis is **structurally** blind here, not unlucky. Its title speaks the outcome's vocabulary (*"An external plane cannot recover itself…"*), sharing no keywords with a newcomer's framing of that same outcome, so title search misses it too.
+An outcome authority does not churn, so it sits permanently outside `(i)`'s window and its title speaks the outcome's vocabulary rather than a newcomer's — both artifact axes miss it, for different reasons. The cost is topology: competing roots split sub-attachment, review attention and closure authority until someone folds them.
 
-**Why the cost is topology, not tidiness.** A duplicate leaf is one closure. Competing Epic roots split *sub-attachment, review attention and closure authority* until someone reconciles them — and each sub filed under the wrong root deepens the split.
-
-> **Empirical anchor — `neomjs/neo-agent-brain#38` vs open `#54`, 2026-08-13.** `#38` was filed as a parentless root duplicating `#54`'s outcome authority: two roots, 17 and 16 children, the same two terminal predicates. The author's §1a sweep was run honestly and **passed** — latest-20 open, title-keyword search, A2A claim scan. A peer's Stage-1 epic review caught it after filing, and the fold cost more than the filing saved.
+> **Anchor — `neomjs/neo-agent-brain#38` vs open `#54`, 2026-08-13.** Two roots, 17 and 16 children, the same two terminal predicates. The author's §1a sweep ran honestly and **passed**; a peer's epic review caught it after filing.
 
 ## Attestation
 
@@ -83,8 +81,8 @@ Three blind spots, one root — the sweep searched for artifacts, never for deci
 
 Another artifact query would have caught none of them.
 
-**And the herd anchor, for why the sweeps run LAST rather than first.** `#12856`, 2026-06-10: four agents raced an operator's *"one (not all!)"* prompt into three duplicate tickets, every one of them having run the GitHub sweep honestly. The single agent who used a two-phase *claim → re-check → execute* filed zero. Check-at-start freshness decays across a multi-minute protocol; check-at-last collapses the stale window to the create-call gap.
+**Why the sweeps run LAST.** `#12856`, 2026-06-10: four agents raced one prompt into three duplicates, each having swept honestly; the one who re-checked immediately before filing produced none. Check-at-start decays across a multi-minute protocol.
 
 ## Sunset
 
-When `ticket-create` gains a mechanical pre-flight that runs the sweeps itself, arms `(i)`–`(iv)` collapse into that runner and this payload retires with them. Arm `(v)` is the exception and survives it: a runner can list open Epics, but *"do these two finish the same sentence?"* is a judgement no lint makes. Expect `(v)` to become a prompt the runner asks, not a check it performs.
+When `ticket-create` gains a mechanical pre-flight that runs the sweeps itself, arms `(i)`–`(iv)` collapse into that runner and this payload retires with them. `(v)` survives it as a prompt rather than a check: a runner can list open Epics, but *"do these two finish the same sentence?"* is not a judgement a lint makes.

--- a/.agents/skills/ticket-create/references/decision-substrate-sweeps.md
+++ b/.agents/skills/ticket-create/references/decision-substrate-sweeps.md
@@ -1,4 +1,4 @@
-# Decision-substrate sweeps — arms `(iii)` and `(iv)` of §1a
+# Decision-substrate sweeps — arms `(iii)`, `(iv)` and `(v)` of §1a
 
 `ticket-create-workflow.md` §1a arms `(i)` and `(ii)`, and the `resources/content` greps beside them, are all **artifact** substrates. They answer *"does a ticket exist?"* None answers *"was this already decided, and why?"*
 
@@ -36,6 +36,22 @@ Then read the **bodies** of the two or three touching the same surface — not t
 
 Neither `(i)` (recency-bounded) nor a closed-issue search reaches an **open, old, self-assigned** parent. A defect found *while measuring something else* is the high-risk shape: it feels like discovery precisely because no retrieval preceded it.
 
+## (v) Epic-layer outcome-authority sweep
+
+Fires only on **epic-labeled** filings.
+
+```bash
+gh issue list --repo <r> --label epic --state open --json number,title
+```
+
+Read **every** row — there are few — plus one semantic outcome-overlap query. Compare **terminal predicates**, not titles: *what state of the world does this Epic declare finished?* Two Epics that finish the same sentence are one Epic, however differently they open.
+
+**Why `(i)` cannot reach these.** An outcome authority is defined by not churning: it is filed once, then supervises for weeks. That places it permanently outside a latest-20 window, so the recency axis is not merely unlucky here — it is **structurally** blind. And its title is written in the vocabulary of the outcome (*"An external plane cannot recover itself…"*), which shares no keywords with a newcomer's framing of the same outcome, so title search misses it too. Both existing artifact axes fail on the same filing for different reasons.
+
+**Why the cost is topology, not tidiness.** A duplicate leaf is one closure. Competing Epic roots split *sub-attachment, review attention and closure authority* until someone reconciles them — and each sub filed under the wrong root deepens the split.
+
+> **Empirical anchor — `neomjs/neo-agent-brain#38` vs open `#54`, 2026-08-13.** `#38` was filed as a parentless root duplicating `#54`'s outcome authority: two roots, 17 and 16 children, the same two terminal predicates. The author's §1a sweep was run honestly and **passed** — latest-20 open, title-keyword search, A2A claim scan. A peer's Stage-1 epic review caught it after filing, and the fold cost more than the filing saved.
+
 ## Attestation
 
 Record what ran, in the body, beside the live-open attestation:
@@ -43,6 +59,7 @@ Record what ran, in the body, beside the live-open attestation:
 ```
 MC sweep: <queries>, <n> results, no prior decision found
 Own-assignment sweep: <n> open, none overlapping
+Epic sweep: <n> open epics read, no shared terminal predicate    # epic-labeled filings only
 ```
 
 Prose discipline that leaves no artifact cannot be checked, and these arms exist because prose discipline failed.
@@ -62,9 +79,12 @@ Three blind spots, one root — the sweep searched for artifacts, never for deci
 | recency-shaped | the standing parent is older than the latest-20 window |
 | open/closed-shaped | the decline lives in a closed issue; `(i)` reads open |
 | ownership-shaped | the parent is open, old, and already assigned to the filer |
+| authority-shaped | the standing Epic is open, old, owned by **someone else**, and titled in the outcome's vocabulary — arm `(v)` |
 
-A fourth artifact query would have caught none of them.
+Another artifact query would have caught none of them.
+
+**And the herd anchor, for why the sweeps run LAST rather than first.** `#12856`, 2026-06-10: four agents raced an operator's *"one (not all!)"* prompt into three duplicate tickets, every one of them having run the GitHub sweep honestly. The single agent who used a two-phase *claim → re-check → execute* filed zero. Check-at-start freshness decays across a multi-minute protocol; check-at-last collapses the stale window to the create-call gap.
 
 ## Sunset
 
-When `ticket-create` gains a mechanical pre-flight that runs the sweeps itself, arms `(i)`–`(iv)` collapse into that runner and this payload retires with them.
+When `ticket-create` gains a mechanical pre-flight that runs the sweeps itself, arms `(i)`–`(iv)` collapse into that runner and this payload retires with them. Arm `(v)` is the exception and survives it: a runner can list open Epics, but *"do these two finish the same sentence?"* is a judgement no lint makes. Expect `(v)` to become a prompt the runner asks, not a check it performs.

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -17,8 +17,6 @@ Verify no equivalent ticket already exists. Redundant tickets pollute the Knowle
 
 Duplicates hide in **two substrates**, and you MUST sweep **both as the LAST step immediately before `create_issue`** — not at turn-start, not when you begin drafting. A sweep run before authoring goes stale while you write the Fat Ticket: in a thundering herd (multiple agents booting on the same prompt), a peer's ticket can land in the minutes between your sweep and your create call. The turn-start mailbox check (`§mailbox_check_protocol`) is for general coordination — it is **not** the dup gate.
 
-> **Empirical anchor (`#12856`, 2026-06-10):** four agents raced an operator's "one (not all!)" prompt → three duplicate tickets, despite every agent running the GitHub sweep honestly. The one agent who used a two-phase *claim → re-check → execute* filed zero. Check-at-start freshness decays across a multi-minute protocol; check-at-last collapses the stale window to the create-call gap.
-
 **(i) GitHub live freshness sweep (mandatory) — catches already-FILED duplicates:** read at least the latest 20 open GitHub issues from the live tracker, including issue number, title, author, labels, and URL.
 
 ```bash
@@ -43,7 +41,9 @@ list_messages({ status: 'all', limit: 30 })  // ALL read-states — recency is t
 
 **(iii) Memory Core rationale sweep + (iv) own-assignment sweep (both mandatory):** `(i)`, `(ii)` and the greps below are all **artifact** substrates — they answer *"does a ticket exist?"*, never *"was this already decided, and why?"* Run one `query_raw_memories` keyed on the **problem's** nouns (the symptom as observed, never the mechanism you are about to build), and `gh issue list --state open --assignee @me` reading the **bodies** of same-surface hits. Both attest in the body like `(i)` does.
 
-<!-- trigger: filing a ticket, or a defect found while measuring something else -> read ./decision-substrate-sweeps.md (query shape, attestation lines, same-turn porting, the #17997 anchor) -->
+**(v) Epic-layer sweep (epic-labeled filings only, mandatory):** outcome authorities do not churn, so `(i)`'s recency axis is blind to them, and their titles share no keywords with a newcomer's framing of the same outcome. Read **every** open `label:epic` issue — one page — plus one outcome-overlap query, and attest beside `(i)`.
+
+<!-- trigger: filing a ticket, filing an EPIC, or a defect found while measuring something else -> read ./decision-substrate-sweeps.md (query shape, the epic sweep, attestation lines, same-turn porting, the #17997 / #12856 anchors) -->
 
 ```
 grep on resources/content/issues/       # active + archived tickets

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -41,7 +41,7 @@ list_messages({ status: 'all', limit: 30 })  // ALL read-states — recency is t
 
 **(iii) Memory Core rationale sweep + (iv) own-assignment sweep (both mandatory):** `(i)`, `(ii)` and the greps below are all **artifact** substrates — they answer *"does a ticket exist?"*, never *"was this already decided, and why?"* Run one `query_raw_memories` keyed on the **problem's** nouns (the symptom as observed, never the mechanism you are about to build), and `gh issue list --state open --assignee @me` reading the **bodies** of same-surface hits. Both attest in the body like `(i)` does.
 
-**(v) Epic-layer sweep (epic-labeled filings only, mandatory):** outcome authorities do not churn, so `(i)`'s recency axis is blind to them, and their titles share no keywords with a newcomer's framing of the same outcome. Read **every** open `label:epic` issue — one page — plus one outcome-overlap query, and attest beside `(i)`.
+**(v) Epic-layer sweep (epic-labeled filings only, mandatory):** both artifact axes are blind to an outcome authority — the payload says why. Read every open `label:epic` issue's `Terminal predicate:` line, then body-read only what an outcome-overlap query ranks, and attest beside `(i)`.
 
 <!-- trigger: filing a ticket, filing an EPIC, or a defect found while measuring something else -> read ./decision-substrate-sweeps.md (query shape, the epic sweep, attestation lines, same-turn porting, the #17997 / #12856 anchors) -->
 


### PR DESCRIPTION
Resolves #9

§1a gains arm `(v)`: before an epic-labeled filing, read **every** open `label:epic` issue — there are few — and compare **terminal predicates** rather than titles. *What state of the world does this Epic declare finished?* Two Epics that finish the same sentence are one Epic, however differently they open.

Evidence: L1 (substrate/prose change; the corpus lint and the package's own test suite are the executable surface) → L1 required (no runtime behaviour changes). No residuals.

## AC Evidence

| AC-1 | `ticket-create-workflow.md` §1a carries arm `(v)` with the mandate and the attestation requirement; the `neo-agent-brain#38`/`#54` anchor lands in `decision-substrate-sweeps.md` beside the payload's existing anchors rather than in §1a — see the byte constraint under Deltas. |
| AC-2 | `epic-create-workflow.md` Procedure step 1 now reads *"Confirm Epic-shape, then run the epic-layer sweep"* and **points at** §1a arm `(v)`. One owner, one pointer — the rule is not restated there. |
| AC-3 | The payload's `## Attestation` block gains `Epic sweep: <n> open epics read, no shared terminal predicate` alongside the existing MC and own-assignment lines, scoped `# epic-labeled filings only`. |

## Deltas from ticket

- **The anchor could not go where the ticket implied.** `ticket-create-workflow.md` was at **24931 / 25000 bytes** — 69 bytes of headroom against `perFilePayloadBudget`, which `#33`'s own PR body predicted would force the next edit to be an extraction rather than a paragraph. So arm `(v)`'s mandate lands in §1a and its evidence lands in the payload, and the `#12856` herd anchor moved out of §1a into `decision-substrate-sweeps.md`'s `## Empirical anchor` section — evidence, in the file that already keeps evidence. Net **24913 / 25000**, headroom 69 → 87.

  That is a thin win and worth stating plainly rather than dressing up: this file remains effectively full, and the next addition to §1a needs a real extraction. The obvious candidate is the arm-`(ii)` **Tiebreak** paragraph (~810 bytes, fires only on a contested lane), but it is not a decision-substrate sweep and moving it into this payload would mis-file it — a sibling payload or a `lane-intent` home is a separate decision, not something to smuggle into this PR.

- **`(v)` is scoped to epic-labeled filings**, not to every ticket. Running an all-epics read before every leaf filing would be the cost that gets a gate muted within a week.

- **The sunset clause changed, and this is the part I would most want challenged.** The payload previously said arms `(i)`–`(iv)` collapse into a future mechanical pre-flight and the payload retires with them. `(v)` is recorded as surviving that: a runner can *list* open Epics, but *"do these two finish the same sentence?"* is a judgement no lint makes, so `(v)` becomes a prompt the runner asks rather than a check it performs. If a reviewer thinks that over-claims — that outcome overlap is mechanizable — the sunset line is where to push.

- **The blind-spot table gains a fourth row.** The payload's `#17997` anchor already enumerated three blind spots (recency-, open/closed-, ownership-shaped) and closed with *"a fourth artifact query would have caught none of them."* `(v)` is the fourth blind spot of the same family — **authority-shaped**: open, old, owned by *someone else*, and titled in the outcome's vocabulary. The table was one row short of its own argument.

## Test Evidence

All coverage runs in CI.

Two local receipts worth recording, since neither is a CI count:

- `npm run --silent lint` → exit 0: *"skill-corpus: 37 skills, coherent with the manifest, within budget, document reach canonical."* The budget assertion is the one that matters here.
- `npm run --silent test` → **24/25**, with `a clean non-Neo consumer resolves projected document references` failing. **Pre-existing, not this change:** I stashed all three edited files, re-ran the suite against pristine `dev`, and the same test failed identically (`materialization check FAILED (38)`), then restored. It reproduces in this local environment, whose `.claude/skills` projection is stale against `node_modules`; whether it also fails on a clean CI runner is visible on this PR's own checks rather than assumed here.

## Post-Merge Validation

- [ ] The next epic-labeled filing by any seat carries an `Epic sweep:` attestation line.
- [ ] `ticket-create-workflow.md` stays under budget on the following substrate PR — at 87 bytes of headroom the next §1a addition should arrive as an extraction, and if it arrives as prose the corpus lint is the thing that says so.

## Commits

- `2d8a407` — arm `(v)`, the payload sections, the epic-create pointer, and the anchor move
- `12057bc` — the corpus-growth examination (below)

## Corpus growth — examined, not waived

The net-growth arm measured **2975 bytes** against `27ad8959` and failed: *"Growth is allowed; unexamined growth is not."* Correct call by the guard, and the honest answer was not a marker on unchanged prose.

- **Trimmed the one genuine redundancy** — the `(i)`-blindness paragraph restated the `authority-shaped` row of the blind-spot table it sits above. 2975 → **2858**.
- **Kept the rest, with the reason in the commit message.** The mandate is two sentences; the remaining bytes are the three things that make `(v)` an arm rather than a preference: the `neo-agent-brain#38`-vs-`#54` anchor (a §1a sweep run honestly that *passed* while duplicating an open Epic — the falsifier), the mechanism (recency and title axes failing on one filing for different reasons), and the severity (competing roots split sub-attachment, review attention and closure authority). Deleting any of the three would shrink the section and gut the argument.
- **Accretion disposition** per `AGENTS.md §self_evolving_systems`: this PR does not net-reduce, so it owes a retirement trigger. Named in the commit and in the payload's `## Sunset` — arm `(v)` survives the future mechanical pre-flight in *reduced* form (a prompt the runner asks, not a check it performs), at which point the section sheds both blindness paragraphs and keeps the anchor.

`[TOOLING_GAP]` — **the justification marker is single-line-only, and nothing says so.** The guard's regex is `/\[skill-growth-justified:\s*[^\]\n]+\]/i`; `[^\]\n]+` excludes newlines, so a wrapped multi-line justification never matches. My first attempt was a paragraph-shaped reason inside the brackets and the arm stayed red with the identical message, which gives the author no signal that the *shape* was the problem rather than the reasoning. A real justification is naturally multi-line. Filing this separately rather than smuggling a guard change into this PR.

## CI state

The `corpus` check is red on this head for a reason that is **not this change**, and the falsifier is recorded rather than asserted:

- The failing step is `Reusable PR baseline contract` (`scripts/test-reusable-pr-baseline.mjs`), reporting `package version drift`, `substrate package version drift`, `PR-body package version drift`.
- `dev` itself is red: run at `27ad8959` (`v0.1.3`) **failure**, the commit before it (`aae27168`) **success**.
- Checked out base `27ad8959` clean — none of my edits present — and ran the script locally: exit 1, identical assertion.

That is @neo-opus-ada's claimed lane (`#27`, claimed 21:35Z: *"the v0.1.3 cut tripped the pin's own contract test"*). **This PR's own arm — net corpus growth — passes at head**, verified locally at exit 0: *"skill-corpus: 37 skills, coherent with the manifest, within budget, document reach canonical."* This PR is merge-blocked on `#27`, not on its own diff.

Authored by Grace (Anthropic Claude Opus 5, Claude Code). Session 5e4492c2-ace7-47e8-83bf-98ccca3a684b.

