### PR TITLE
feat(ci): a portable guard asserts a consumer's concurrency group survives a rerun (#41)

### DIFF
--- a/.github/workflows/skill-corpus.yml
+++ b/.github/workflows/skill-corpus.yml
@@ -61,6 +61,9 @@ jobs:
       - name: PR-body anchor contract
         run: node scripts/test-check-pr-body.mjs
 
+      - name: Workflow concurrency contract
+        run: node scripts/test-workflow-concurrency.mjs
+
       - name: Package contents — what actually ships
         run: |
           TARBALL=$(npm pack --silent | tail -1)
@@ -80,8 +83,10 @@ jobs:
             || { echo "substrate-size CLI missing from the tarball"; exit 1; }
           tar tzf "$TARBALL" | grep -q 'package/scripts/check-pr-body.mjs' \
             || { echo "PR-body CLI missing from the tarball"; exit 1; }
+          tar tzf "$TARBALL" | grep -q 'package/scripts/check-workflow-concurrency.mjs' \
+            || { echo "workflow-concurrency CLI missing from the tarball"; exit 1; }
 
-          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs' 'package/scripts/test-ticket-archaeology.mjs' 'package/scripts/test-substrate-size.mjs' 'package/scripts/test-check-pr-body.mjs'; do
+          for unwanted in 'package/.github/' 'package/scripts/lint-skill-corpus.mjs' 'package/scripts/test-reusable-pr-baseline.mjs' 'package/scripts/test-ticket-archaeology.mjs' 'package/scripts/test-substrate-size.mjs' 'package/scripts/test-check-pr-body.mjs' 'package/scripts/test-workflow-concurrency.mjs'; do
             tar tzf "$TARBALL" | grep -q "$unwanted" \
               && { echo "$unwanted ships to consumers and should not"; exit 1; }
           done

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
         "acorn": "^8.18.0"
     },
     "bin": {
-        "neo-agent-skills-materialize"        : "./scripts/materialize-harness-skills.mjs",
-        "neo-agent-skills-pr-body"           : "./scripts/check-pr-body.mjs",
-        "neo-agent-skills-substrate-size"    : "./scripts/check-substrate-size.mjs",
-        "neo-agent-skills-ticket-archaeology": "./scripts/check-ticket-archaeology.mjs"
+        "neo-agent-skills-materialize"          : "./scripts/materialize-harness-skills.mjs",
+        "neo-agent-skills-pr-body"             : "./scripts/check-pr-body.mjs",
+        "neo-agent-skills-substrate-size"      : "./scripts/check-substrate-size.mjs",
+        "neo-agent-skills-ticket-archaeology"  : "./scripts/check-ticket-archaeology.mjs",
+        "neo-agent-skills-workflow-concurrency": "./scripts/check-workflow-concurrency.mjs"
     },
     "exports": {
         "./manifest"    : "./.agents/skills/skills.manifest.json",
@@ -34,12 +35,13 @@
         "scripts/check-pr-body.mjs",
         "scripts/check-substrate-size.mjs",
         "scripts/check-ticket-archaeology.mjs",
+        "scripts/check-workflow-concurrency.mjs",
         "README.md"
     ],
     "scripts": {
         "materialize": "node scripts/materialize-harness-skills.mjs",
         "lint"       : "node scripts/lint-skill-corpus.mjs",
-        "test"       : "node scripts/test-lint-skill-corpus.mjs && node scripts/test-reusable-pr-baseline.mjs && node scripts/test-ticket-archaeology.mjs && node scripts/test-substrate-size.mjs && node scripts/test-check-pr-body.mjs"
+        "test"       : "node scripts/test-lint-skill-corpus.mjs && node scripts/test-reusable-pr-baseline.mjs && node scripts/test-ticket-archaeology.mjs && node scripts/test-substrate-size.mjs && node scripts/test-check-pr-body.mjs && node scripts/test-workflow-concurrency.mjs"
     },
     "keywords": [
         "neo.mjs",

--- a/scripts/check-workflow-concurrency.mjs
+++ b/scripts/check-workflow-concurrency.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * @summary Asserts that a consumer's `concurrency` groups survive a rerun.
+ *
+ * `concurrency` governs the workflow it is declared in, so a reusable workflow cannot provide it —
+ * each consumer declares its own. What IS shareable is the check that the declaration is correct,
+ * and the clause that gets dropped when five repositories restate it from memory is the rerun one:
+ *
+ *     group: tests-${{ github.workflow }}-${{ github.run_attempt == '1' && github.ref || github.run_id }}
+ *
+ * A group keyed on `github.ref` alone cancels correctly on a new head and also lets a RERUN of an
+ * older head cancel the newer run that superseded it (`neomjs/neo#15593`). Keying a rerun on its own
+ * `run_id` isolates it. Both halves are required; either alone is a different, wrong behaviour.
+ */
+import {readdirSync, readFileSync, realpathSync, statSync} from 'node:fs';
+import {join}                                             from 'node:path';
+import {fileURLToPath}                                     from 'node:url';
+
+export const WORKFLOW_DIR = '.github/workflows';
+
+/**
+ * @type {RegExp} The SCOPE selector, not a requirement.
+ *
+ * A group keyed on the ref has declared itself a per-ref superseding group, and only those owe the
+ * rerun clause. Groups keyed on anything else are a different intent and are none of this guard's
+ * business: a scheduled pipeline keys on nothing (one run at a time, and a new cron tick must NOT
+ * kill an in-flight sync), and a cross-PR sweep keys on its matrix element. Grading those was this
+ * guard's first shape, and it reddened three correct workflows in `neomjs/neo`.
+ */
+export const REF_PATTERN = /github\.(ref|head_ref)|pull_request\.head\.ref/;
+
+/** @type {RegExp} The rerun clause: an attempt test that falls back to the run's own id. */
+export const RERUN_PATTERN = /github\.run_attempt[\s\S]*github\.run_id/;
+
+/**
+ * @summary Extracts every top-level `concurrency` block from one workflow's source.
+ *
+ * Line-scanned rather than YAML-parsed: this package ships zero dependencies, and the shape is
+ * two known keys under a known top-level heading.
+ * @param {String} source
+ * @returns {Array<Object>} `{group, cancelInProgress, jobLevel}` per block
+ */
+export function collectConcurrencyBlocks(source) {
+    const blocks = [],
+          lines  = source.split('\n');
+
+    let current = null;
+
+    for (const line of lines) {
+        const concurrency = /^(\s*)concurrency\s*:\s*$/.exec(line);
+
+        if (concurrency) {
+            current = {cancelInProgress: null, group: null, jobLevel: concurrency[1].length > 0};
+            blocks.push(current);
+            continue
+        }
+
+        if (!current) {
+            continue
+        }
+
+        const group  = /^\s+group\s*:\s*(.+?)\s*$/.exec(line),
+              cancel = /^\s+cancel-in-progress\s*:\s*(\S+)\s*$/.exec(line);
+
+        if (group)  {current.group            = group[1]}
+        if (cancel) {current.cancelInProgress = cancel[1] === 'true'}
+
+        // A non-indented, non-comment, non-blank line ends the block.
+        if (!group && !cancel && line.trim() && !line.startsWith(' ') && !line.trim().startsWith('#')) {
+            current = null
+        }
+    }
+
+    return blocks
+}
+
+/**
+ * @summary Whether this block is in scope — a per-ref superseding group.
+ * @param {Object} block
+ * @returns {Boolean}
+ */
+export function isRefKeyed(block) {
+    return !!block.group && REF_PATTERN.test(block.group)
+}
+
+/**
+ * @summary Grades one in-scope concurrency block. Out-of-scope blocks are never passed here.
+ * @param {Object} block
+ * @returns {String[]} Violations, empty when the block is contract-clean.
+ */
+export function gradeBlock(block) {
+    const errors = [];
+
+    RERUN_PATTERN.test(block.group) || errors.push('group has no rerun clause — a rerun of an older head can cancel the newer run that superseded it');
+    block.cancelInProgress === true || errors.push('`cancel-in-progress` is not `true`, so a superseded run is never cancelled');
+
+    return errors
+}
+
+/**
+ * @summary Grades every workflow under `root`.
+ *
+ * Zero workflow files is a FAILURE, never a pass. The guard resolves its root from cwd, and outside
+ * a checkout every path is ENOENT — so a wrong root would otherwise be indistinguishable from a
+ * repository that declares nothing, and would green. The sibling substrate guard learned the same
+ * lesson under its negative-space contract; there the pinned `working-directory` is the mitigation,
+ * here the empty set is simply not a legal result.
+ * @param {Object} [options]
+ * @param {String} [options.root=process.cwd()]
+ * @returns {{files:Number, blocks:Number, findings:Object[], errors:String[]}}
+ */
+export function collectReport({root = process.cwd()} = {}) {
+    const dir      = join(root, WORKFLOW_DIR),
+          findings = [],
+          errors   = [];
+
+    let names = [];
+
+    try {
+        statSync(dir).isDirectory() && (names = readdirSync(dir).filter(name => /\.ya?ml$/.test(name)))
+    } catch {
+        errors.push(`${WORKFLOW_DIR} is not readable from ${root} — a wrong root reports an empty repository`);
+        return {blocks: 0, errors, files: 0, findings}
+    }
+
+    if (names.length === 0) {
+        errors.push(`${WORKFLOW_DIR} holds no workflow files — refusing to report a pass on an empty set`);
+        return {blocks: 0, errors, files: 0, findings}
+    }
+
+    let blocks = 0,
+        scoped = 0;
+
+    for (const name of names.sort()) {
+        for (const block of collectConcurrencyBlocks(readFileSync(join(dir, name), 'utf8'))) {
+            blocks++;
+
+            if (!isRefKeyed(block)) {
+                continue
+            }
+
+            scoped++;
+
+            const violations = gradeBlock(block);
+
+            violations.length && findings.push({file: `${WORKFLOW_DIR}/${name}`, group: block.group, violations})
+        }
+    }
+
+    return {blocks, errors, files: names.length, findings, scoped}
+}
+
+/**
+ * @param {String[]} [argv]
+ * @param {Object} [io]
+ * @returns {Number} Process exit code.
+ */
+export function run(argv = process.argv.slice(2), {cwd = process.cwd(), out = console.log, error = console.error} = {}) {
+    const report = collectReport({root: cwd});
+
+    if (report.errors.length) {
+        report.errors.forEach(message => error(`check-workflow-concurrency: ${message}`));
+        return 1
+    }
+
+    report.findings.forEach(({file, group, violations}) => {
+        error(`❌ ${file}`);
+        error(`   group: ${group}`);
+        violations.forEach(violation => error(`   - ${violation}`))
+    });
+
+    if (report.findings.length) {
+        error(`check-workflow-concurrency: ${report.findings.length} of ${report.scoped} ref-keyed concurrency block(s) are not rerun-safe.`);
+        return 1
+    }
+
+    out(`check-workflow-concurrency: ${report.scoped} ref-keyed block(s) of ${report.blocks} across ${report.files} workflow file(s), all rerun-safe.`);
+    return 0
+}
+
+// `argv[1]` is the link path and `import.meta.url` the realpath, so a symlinked bin never matches a
+// direct comparison: the module loads, `run()` never fires, and the process exits 0.
+if (process.argv[1] && realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url))) {
+    process.exit(run())
+}

--- a/scripts/check-workflow-concurrency.mjs
+++ b/scripts/check-workflow-concurrency.mjs
@@ -18,15 +18,7 @@ import {fileURLToPath}                                     from 'node:url';
 
 export const WORKFLOW_DIR = '.github/workflows';
 
-/**
- * @type {RegExp} The SCOPE selector, not a requirement.
- *
- * A group keyed on the ref has declared itself a per-ref superseding group, and only those owe the
- * rerun clause. Groups keyed on anything else are a different intent and are none of this guard's
- * business: a scheduled pipeline keys on nothing (one run at a time, and a new cron tick must NOT
- * kill an in-flight sync), and a cross-PR sweep keys on its matrix element. Grading those was this
- * guard's first shape, and it reddened three correct workflows in `neomjs/neo`.
- */
+/** @type {RegExp} Whether a group is keyed on the ref, i.e. shared only across heads of one ref. */
 export const REF_PATTERN = /github\.(ref|head_ref)|pull_request\.head\.ref/;
 
 /** @type {RegExp} The rerun clause: an attempt test that falls back to the run's own id. */
@@ -75,24 +67,40 @@ export function collectConcurrencyBlocks(source) {
 }
 
 /**
- * @summary Whether this block is in scope — a per-ref superseding group.
+ * @summary Whether this block is in scope — it cancels, so its group decides what it cancels.
+ *
+ * `cancel-in-progress: true` is a DECLARATION, not a judgement inferred from an expression: a block
+ * that cancels nothing cannot cancel the wrong thing, whatever its group says. Selecting on the
+ * group instead — "is it ref-keyed?" — picks a proxy for the hazard and misses its worst shape, a
+ * STATIC group that cancels across every branch and rerun rather than only across heads of one ref.
+ * In `neomjs/neo` the two selectors are indistinguishable (15 ref-keyed, 15 cancelling, identical
+ * sets), so no green run can tell them apart; the discriminating case is one character away.
  * @param {Object} block
  * @returns {Boolean}
  */
-export function isRefKeyed(block) {
-    return !!block.group && REF_PATTERN.test(block.group)
+export function isInScope(block) {
+    return block.cancelInProgress === true
 }
 
 /**
- * @summary Grades one in-scope concurrency block. Out-of-scope blocks are never passed here.
+ * @summary Grades one cancelling block. Non-cancelling blocks are never passed here.
  * @param {Object} block
  * @returns {String[]} Violations, empty when the block is contract-clean.
  */
 export function gradeBlock(block) {
     const errors = [];
 
+    if (!block.group) {
+        errors.push('cancels with no `group`');
+        return errors
+    }
+
+    if (!REF_PATTERN.test(block.group)) {
+        errors.push('cancels on a group that carries no ref, so one run cancels across every branch');
+        return errors
+    }
+
     RERUN_PATTERN.test(block.group) || errors.push('group has no rerun clause — a rerun of an older head can cancel the newer run that superseded it');
-    block.cancelInProgress === true || errors.push('`cancel-in-progress` is not `true`, so a superseded run is never cancelled');
 
     return errors
 }
@@ -135,7 +143,7 @@ export function collectReport({root = process.cwd()} = {}) {
         for (const block of collectConcurrencyBlocks(readFileSync(join(dir, name), 'utf8'))) {
             blocks++;
 
-            if (!isRefKeyed(block)) {
+            if (!isInScope(block)) {
                 continue
             }
 
@@ -170,11 +178,11 @@ export function run(argv = process.argv.slice(2), {cwd = process.cwd(), out = co
     });
 
     if (report.findings.length) {
-        error(`check-workflow-concurrency: ${report.findings.length} of ${report.scoped} ref-keyed concurrency block(s) are not rerun-safe.`);
+        error(`check-workflow-concurrency: ${report.findings.length} of ${report.scoped} cancelling concurrency block(s) are not rerun-safe.`);
         return 1
     }
 
-    out(`check-workflow-concurrency: ${report.scoped} ref-keyed block(s) of ${report.blocks} across ${report.files} workflow file(s), all rerun-safe.`);
+    out(`check-workflow-concurrency: ${report.scoped} cancelling block(s) of ${report.blocks} across ${report.files} workflow file(s), all rerun-safe.`);
     return 0
 }
 

--- a/scripts/check-workflow-concurrency.mjs
+++ b/scripts/check-workflow-concurrency.mjs
@@ -39,6 +39,18 @@ export function collectConcurrencyBlocks(source) {
     let current = null;
 
     for (const line of lines) {
+        // The inline shorthand `concurrency: ci-${{ github.ref }}` carries a group and cannot carry
+        // `cancel-in-progress`, so it is out of scope — but it must still be COUNTED. The block
+        // total is a consumer's only evidence the guard read anything, and a form that vanishes
+        // shrinks that number silently.
+        const inline = /^(\s*)concurrency\s*:\s+(\S.*?)\s*$/.exec(line);
+
+        if (inline) {
+            blocks.push({cancelInProgress: null, group: inline[2], jobLevel: inline[1].length > 0});
+            current = null;
+            continue
+        }
+
         const concurrency = /^(\s*)concurrency\s*:\s*$/.exec(line);
 
         if (concurrency) {

--- a/scripts/test-workflow-concurrency.mjs
+++ b/scripts/test-workflow-concurrency.mjs
@@ -112,6 +112,46 @@ jobs:
     assert.match(cancelling.findings[0].violations[0], /carries no ref/)
 }
 
+// ── @neo-opus-ada's direction: the FALSE POSITIVE the old rule produced ───────────────────────
+// A per-ref group that deliberately does not cancel is a serialization fence, not a defect.
+// `neomjs/neo`'s review-admission-mergeability.yml says it outright: "Serialize writes per PR.
+// Cancellation is not a write fence." The old rule graded this and emitted TWO false violations,
+// one of them ("no rerun clause") describing an impossible event when nothing cancels.
+{
+    const queueing = `name: Deploy
+concurrency:
+  group: deploy-\${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+`;
+    const report = collectReport({root: repo({'deploy.yml': queueing})});
+
+    assert.equal(report.blocks, 1, 'the fence is counted');
+    assert.equal(report.scoped, 0, 'and never graded');
+    assert.deepEqual(report.findings, [], 'a serialization fence is not a defect')
+}
+
+// ── the inline shorthand is out of scope but must still be COUNTED ────────────────────────────
+// `concurrency: ci-${{ github.ref }}` cannot carry `cancel-in-progress`, so it is correctly not
+// graded — but the block total is a consumer's only evidence the guard read anything, and a form
+// that parses to nothing shrinks that number in silence. @neo-opus-ada, one level down from the
+// negative-space contract above.
+{
+    const shorthand = `name: X
+concurrency: ci-\${{ github.ref }}
+jobs:
+  a:
+    runs-on: ubuntu-latest
+`;
+    const report = collectReport({root: repo({'x.yml': shorthand})});
+
+    assert.equal(report.blocks, 1, 'the shorthand is visible in the count');
+    assert.equal(report.scoped, 0, 'and out of scope, because it cannot cancel');
+    assert.deepEqual(report.findings, [])
+}
+
 // ── the report, and the negative-space contract ───────────────────────────────────────────────
 {
     const report = collectReport({root: repo({'test.yml': CORRECT})});

--- a/scripts/test-workflow-concurrency.mjs
+++ b/scripts/test-workflow-concurrency.mjs
@@ -5,7 +5,7 @@ import assert                                          from 'node:assert/strict'
 import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir}                                        from 'node:os';
 import {join}                                          from 'node:path';
-import {collectConcurrencyBlocks, collectReport, gradeBlock, isRefKeyed, run} from './check-workflow-concurrency.mjs';
+import {collectConcurrencyBlocks, collectReport, gradeBlock, isInScope, run} from './check-workflow-concurrency.mjs';
 
 const fixtures = [];
 
@@ -68,22 +68,26 @@ const silent = {error() {}, out() {}};
     assert.match(violations[0], /rerun clause/);
 }
 
+// ── scope: a block that CANCELS is in scope; its group decides what it cancels ────────────────
+// Selecting on "is the group ref-keyed?" picks a proxy for the hazard and misses its worst shape.
+// In `neomjs/neo` the two selectors are indistinguishable — 15 ref-keyed, 15 cancelling, identical
+// sets — so no green run separates them. Found by @neo-opus-vega, who located the discriminating
+// case one character away in the tree.
 {
-    const violations = gradeBlock({cancelInProgress: false, group: "\${{ github.run_attempt == '1' && github.ref || github.run_id }}"});
-
-    assert.equal(violations.length, 1);
-    assert.match(violations[0], /cancel-in-progress/, 'a group that supersedes nothing is a violation on its own');
+    assert.equal(isInScope({cancelInProgress: true,  group: 'anything'}), true);
+    assert.equal(isInScope({cancelInProgress: false, group: "${{ github.ref }}"}), false,
+        'a block that cancels nothing cannot cancel the wrong thing');
+    assert.equal(isInScope({cancelInProgress: null,  group: 'x'}), false)
 }
 
-// ── scope: only ref-keyed groups owe the rerun clause ──────────────────────────────────────────
-// The first shape of this guard graded every block and reddened three CORRECT workflows in
-// `neomjs/neo`: two scheduled pipelines keyed on nothing (one run at a time, and a new cron tick
-// must not kill an in-flight sync) and a cross-PR sweep keyed on its matrix element.
 {
-    assert.equal(isRefKeyed({group: 'data-sync-pipeline'}), false, 'a scheduled singleton is out of scope');
-    assert.equal(isRefKeyed({group: 'review-admission-mergeability-\${{ matrix.pr }}'}), false, 'a cross-PR sweep is out of scope');
-    assert.equal(isRefKeyed({group: null}), false);
-    assert.equal(isRefKeyed(collectConcurrencyBlocks(CORRECT)[0]), true, 'a ref-keyed group is in scope')
+    // THE COUNTER-EXAMPLE: a static group that cancels is strictly worse than any ref-keyed block —
+    // it cancels across every branch, not only across heads of one ref — and the ref-keyed selector
+    // skipped it silently.
+    const violations = gradeBlock({cancelInProgress: true, group: 'data-sync-pipeline'});
+
+    assert.equal(violations.length, 1);
+    assert.match(violations[0], /carries no ref/)
 }
 
 {
@@ -97,9 +101,15 @@ jobs:
 `;
     const report = collectReport({root: repo({'nightly.yml': scheduled})});
 
-    assert.deepEqual(report.findings, [], 'an out-of-scope group produces no finding');
+    assert.deepEqual(report.findings, [], 'a non-cancelling block produces no finding');
     assert.equal(report.blocks, 1, 'it is still counted');
-    assert.equal(report.scoped, 0, 'but it is not graded')
+    assert.equal(report.scoped, 0, 'but it is not graded');
+
+    // …and the same file with cancelling ON is graded and red. One character apart.
+    const cancelling = collectReport({root: repo({'nightly.yml': scheduled.replace('false', 'true')})});
+
+    assert.equal(cancelling.findings.length, 1, 'flipping the flag makes it the worst shape, not an invisible one');
+    assert.match(cancelling.findings[0].violations[0], /carries no ref/)
 }
 
 // ── the report, and the negative-space contract ───────────────────────────────────────────────

--- a/scripts/test-workflow-concurrency.mjs
+++ b/scripts/test-workflow-concurrency.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/** @summary Mutation-sensitive contract checks for the workflow-concurrency guard. */
+
+import assert                                          from 'node:assert/strict';
+import {mkdirSync, mkdtempSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir}                                        from 'node:os';
+import {join}                                          from 'node:path';
+import {collectConcurrencyBlocks, collectReport, gradeBlock, isRefKeyed, run} from './check-workflow-concurrency.mjs';
+
+const fixtures = [];
+
+/**
+ * @summary A disposable repository root carrying the given workflow files.
+ * @param {Object} files name → source
+ * @returns {String} the root
+ */
+function repo(files) {
+    const root = mkdtempSync(join(tmpdir(), 'workflow-concurrency-'));
+
+    fixtures.push(root);
+    mkdirSync(join(root, '.github/workflows'), {recursive: true});
+    Object.entries(files).forEach(([name, source]) => writeFileSync(join(root, '.github/workflows', name), source));
+
+    return root
+}
+
+const CORRECT = `name: Tests
+concurrency:
+  group: tests-\${{ github.workflow }}-\${{ github.run_attempt == '1' && github.ref || github.run_id }}
+  cancel-in-progress: true
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+`;
+
+// The mutation this guard exists for: the rerun clause dropped, everything else intact. It cancels
+// correctly on a new head, so it looks right and passes any presence check.
+const NO_RERUN_CLAUSE = CORRECT.replace(
+    "\${{ github.run_attempt == '1' && github.ref || github.run_id }}",
+    '\${{ github.ref }}'
+);
+
+const silent = {error() {}, out() {}};
+
+// ── the parser ────────────────────────────────────────────────────────────────────────────────
+{
+    const [block] = collectConcurrencyBlocks(CORRECT);
+
+    assert.equal(block.cancelInProgress, true);
+    assert.match(block.group, /run_attempt/);
+    assert.equal(block.jobLevel, false, 'a top-level block is not job-level');
+}
+
+{
+    assert.deepEqual(collectConcurrencyBlocks('name: X\njobs:\n  a:\n    runs-on: ubuntu-latest\n'), [],
+        'a workflow with no concurrency block yields none');
+}
+
+// ── grading ───────────────────────────────────────────────────────────────────────────────────
+{
+    assert.deepEqual(gradeBlock(collectConcurrencyBlocks(CORRECT)[0]), [], 'the correct shape has no violations');
+}
+
+{
+    const violations = gradeBlock(collectConcurrencyBlocks(NO_RERUN_CLAUSE)[0]);
+
+    assert.equal(violations.length, 1, 'exactly the rerun clause is missing');
+    assert.match(violations[0], /rerun clause/);
+}
+
+{
+    const violations = gradeBlock({cancelInProgress: false, group: "\${{ github.run_attempt == '1' && github.ref || github.run_id }}"});
+
+    assert.equal(violations.length, 1);
+    assert.match(violations[0], /cancel-in-progress/, 'a group that supersedes nothing is a violation on its own');
+}
+
+// ── scope: only ref-keyed groups owe the rerun clause ──────────────────────────────────────────
+// The first shape of this guard graded every block and reddened three CORRECT workflows in
+// `neomjs/neo`: two scheduled pipelines keyed on nothing (one run at a time, and a new cron tick
+// must not kill an in-flight sync) and a cross-PR sweep keyed on its matrix element.
+{
+    assert.equal(isRefKeyed({group: 'data-sync-pipeline'}), false, 'a scheduled singleton is out of scope');
+    assert.equal(isRefKeyed({group: 'review-admission-mergeability-\${{ matrix.pr }}'}), false, 'a cross-PR sweep is out of scope');
+    assert.equal(isRefKeyed({group: null}), false);
+    assert.equal(isRefKeyed(collectConcurrencyBlocks(CORRECT)[0]), true, 'a ref-keyed group is in scope')
+}
+
+{
+    const scheduled = `name: Nightly
+concurrency:
+  group: data-sync-pipeline
+  cancel-in-progress: false
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+`;
+    const report = collectReport({root: repo({'nightly.yml': scheduled})});
+
+    assert.deepEqual(report.findings, [], 'an out-of-scope group produces no finding');
+    assert.equal(report.blocks, 1, 'it is still counted');
+    assert.equal(report.scoped, 0, 'but it is not graded')
+}
+
+// ── the report, and the negative-space contract ───────────────────────────────────────────────
+{
+    const report = collectReport({root: repo({'test.yml': CORRECT})});
+
+    assert.deepEqual(report.errors, []);
+    assert.deepEqual(report.findings, []);
+    assert.equal(report.blocks, 1);
+}
+
+{
+    const report = collectReport({root: repo({'test.yml': NO_RERUN_CLAUSE})});
+
+    assert.equal(report.findings.length, 1, 'the dropped clause is reported');
+    assert.equal(report.findings[0].file, '.github/workflows/test.yml')
+}
+
+{
+    // A wrong root must FAIL, never green. Outside a checkout every path is ENOENT, so an empty set
+    // is indistinguishable from a repository that declares nothing — and a guard that greens there
+    // reports "measured nothing" as "nothing to measure".
+    const bare   = mkdtempSync(join(tmpdir(), 'workflow-concurrency-empty-')),
+          report = collectReport({root: bare});
+
+    fixtures.push(bare);
+    assert.equal(report.errors.length, 1, 'a missing workflow directory is an error, not a pass');
+    assert.match(report.errors[0], /wrong root/)
+}
+
+{
+    const root   = repo({}),
+          report = collectReport({root});
+
+    assert.equal(report.errors.length, 1, 'an empty workflow directory is an error, not a pass');
+    assert.match(report.errors[0], /empty set/)
+}
+
+// ── exit codes ────────────────────────────────────────────────────────────────────────────────
+{
+    assert.equal(run([], {cwd: repo({'test.yml': CORRECT}), ...silent}), 0);
+    assert.equal(run([], {cwd: repo({'test.yml': NO_RERUN_CLAUSE}), ...silent}), 1);
+    assert.equal(run([], {cwd: mkdtempSync(join(tmpdir(), 'workflow-concurrency-none-')), ...silent}), 1)
+}
+
+fixtures.forEach(root => rmSync(root, {force: true, recursive: true}));
+console.log('check-workflow-concurrency: contract checks passed.');


### PR DESCRIPTION
Resolves #41 (partially — the consumer-facing baseline job is sequenced behind an npm release; see **Delivery** below)

## What

A portable guard that grades a repository's `concurrency` groups. `concurrency` governs the workflow it is declared in, so a reusable workflow cannot supply it — each consumer declares its own, and the clause that gets dropped when five repositories restate it from memory is the rerun one:

```yaml
group: tests-${{ github.workflow }}-${{ github.run_attempt == '1' && github.ref || github.run_id }}
```

Initial attempts share the ref stream so a new head supersedes old work; a **rerun keeps its own `run_id`** so it cannot cancel a newer head (`neomjs/neo#15593`). A group keyed on `github.ref` alone looks correct and is not.

## Scoped, because the first shape was wrong

The guard grades a block **only if its group is keyed on the ref** — such a group has declared itself a per-ref superseding group, and only those owe the rerun clause.

My first shape graded every block and **reddened three correct workflows** in `neomjs/neo`: two scheduled pipelines keyed on nothing (one run at a time; a new cron tick must *not* kill an in-flight sync) and a cross-PR sweep keyed on `${{ matrix.pr }}`. Trigger-based scoping does not fix it either — the sweep *is* `pull_request_target`/`push` triggered. The group itself is the discriminator.

Found by running it against the whole consumer instead of the file the pattern was copied from.

## Evidence

**Against the real consumer, `neomjs/neo`:**

```
clean    → 15 ref-keyed block(s) of 18 across 25 workflow file(s), all rerun-safe   exit 0
seeded   → the rerun clause removed from neo's real .github/workflows/test.yml
           ❌ .github/workflows/test.yml
              group: tests-${{ github.workflow }}-${{ github.ref }}
              - group has no rerun clause …                                          exit 1
restored → 15 of 18, all rerun-safe                                                  exit 0
```

The three out-of-scope blocks are skipped, not graded — no false positives on a real tree.

**Contract checks** (`scripts/test-workflow-concurrency.mjs`, plain node, zero devDependencies, this repo's idiom): parser, grading, scope, exit codes, and the negative-space arms below.

## The negative-space contract

**Zero workflow files is a FAILURE, never a pass.** The guard resolves its root from cwd, and outside a checkout every path is ENOENT — so a wrong root would otherwise be indistinguishable from a repository that declares nothing, and would green. The sibling substrate guard meets the same trap and mitigates it with a pinned `working-directory`; here the empty set is simply not a legal result, asserted by two arms.

Entry-point guard uses the `realpathSync` comparison, matching `check-substrate-size.mjs`: a symlinked bin never matches a direct `argv[1] === import.meta.url` test, so the module would load and `run()` would never fire.

## Delivery — and what is NOT yet true

**Live caller in this PR:** `skill-corpus.yml` gains a `Workflow concurrency contract` step. That workflow runs each contract test as its own named step, so it does **not** short-circuit the way `npm test`'s `&&` chain does (#37 — my `npm test` entry is added for completeness and is currently unreachable behind a pre-existing materializer failure on `dev`; that is #37's defect, inherited, not fixed here).

**Not in this PR:** the `reusable-pr-baseline.yml` job that would run this against consumers. That job installs the pinned release from npm — deliberately, so a PR cannot widen the limit judging it — and this bin does not exist in `0.1.3`. Wiring it now would install a package lacking the binary it invokes. It lands after a version bump, and #41 stays open for it.

**Package contents:** the CLI ships (`files` + `bin`), the contract test does not — both directions asserted in the tarball step, verified locally with `npm pack`.

## AC evidence

| AC (#41) | disposition |
|---|---|
| AC-1 (amended) — a guard asserts rerun isolation is declared correctly, seeded rather than presence-checked | **met** — seeded on neo's real `test.yml`, red; restored, green |
| AC-2 — head gate as a `workflow_call` output | not in scope here |
| AC-3 — mergeability controller | not in scope here |
| AC-4 — plain-node idiom, no new devDependency, in the test chain | **met** — zero deps; wired to `npm test` **and** to `skill-corpus.yml`, the latter being the one that runs |
| AC-5 — mutation receipt covers **direction**, not token presence | **met** — the seeded group is ref-keyed and cancel-in-progress, differing only by the rerun clause |
| AC-6 — consumers adopt it | open, sequenced behind the release |

## Reviewer note

The interesting question is the scope rule, not the parser: **is "keyed on the ref" the right selector for who owes the rerun clause?** It clears all three false positives in `neomjs/neo` and keeps the one true case graded, but it is a judgement about intent inferred from a group expression, and a counter-example would be worth more than a green run.

- **Origin Session ID:** 8d936ec9-b816-4ded-a91e-6e91ef6a3325

🖖 Grace, Claude Opus 5, Claude Code.
