### PR TITLE
docs(skills): the defect-note channel admits what it was already carrying (#43)

### DIFF
--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -274,6 +274,8 @@ until the shape is correct.
 
 Do not copy ticket bodies or the optional external-contributor `.github/PULL_REQUEST_TEMPLATE.md` into agent PRs; summarize the implementation delta below.
 
+Knowingly leaving something unfixed in a file you touched costs one line where it happened — `out of scope, noted in <defect-note|#N>` — with the note filed first (`ticket-create` §1e). No section and no placeholder: a PR with nothing to declare declares nothing.
+
 ### 9.1 Reference Hygiene
 
 Before PR prose, read the [reference-hygiene guide](https://github.com/neomjs/neo-agent-brain/blob/dev/learn/agentos/process/reference-hygiene.md): relationships stay bare; descriptive tokens use backticks.

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -274,7 +274,7 @@ until the shape is correct.
 
 Do not copy ticket bodies or the optional external-contributor `.github/PULL_REQUEST_TEMPLATE.md` into agent PRs; summarize the implementation delta below.
 
-Knowingly leaving something unfixed in a file you touched costs one line where it happened — `out of scope, noted in <defect-note|#N>` — with the note filed first (`ticket-create` §1e). No section and no placeholder: a PR with nothing to declare declares nothing.
+Knowingly leaving something unfixed in a file you touched costs one line there — `out of scope, noted in <defect-note|#N>` — note filed first (`ticket-create` §1e). No section, no placeholder.
 
 ### 9.1 Reference Hygiene
 

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -93,7 +93,7 @@ defect-note: <surface> <broke | is wrong> <observed symptom>
 - **Promotion runs the FULL ceremony** — an issue is created only on a production-down signal, an independent second occurrence, an operator escalation, or a triage decision, and runs this entire workflow, V-B-A included. Capture never waits for any of it.
 - **Recovery is a note too:** `defect-note: [recovered] <surface> broke <symptom>` closes the observation idempotently; a fresh sighting re-opens it.
 - **Promotion/dismissal are notes too:** `defect-note: [promoted #N] <same note>` (any seat) or `defect-note: [dismissed] <same note>` (operator only) — either takes a row off the orchestrator digest (`defectObservations.mjs --digest`).
-- The asymmetry is deliberate: a duplicate note costs one dedup; an unfiled defect costs what an unfiled production break costs (origin: the `query_summaries` specimen, D#17136). **A workaround or scope boundary without a filed defect-note is the named anti-pattern** — the workaround may stay private, the sighting may not. A comment promising two copies stay equal is a note nobody sent.
+- The asymmetry is deliberate: a duplicate note costs one dedup; an unfiled defect costs what an unfiled production break costs (origin: the `query_summaries` specimen, D#17136). **A workaround or scope boundary without a filed defect-note is the named anti-pattern** — the workaround may stay private, the sighting may not.
 
 ## 2. Six-Stage Challenge Chain
 

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -83,17 +83,17 @@ For source anchors (`#11078` / `#11082` / `#11083` / `#11084`), Discussion `#110
 
 ### 1e. The Zero-Ceremony Defect Channel (capture exemption)
 
-Defect CAPTURE is exempt from §1a's sweeps and §2's chain, permanently. On broken substrate — production or local — capture is one A2A line to `AGENT:*`, no sweeps, no body:
+Defect CAPTURE is exempt from §1a's sweeps and §2's chain, permanently. On broken substrate — or working substrate you touched and saw is wrong — production or local — capture is one A2A line to `AGENT:*`, no sweeps, no body:
 
 ```
-defect-note: <surface> broke <observed symptom>
+defect-note: <surface> <broke | is wrong> <observed symptom>
 ```
 
 - **Capture ≠ admission.** Notes fold into one standing observation per surface/symptom fingerprint (read model: `ai/services/memory-core/helpers/defectObservationFold.mjs`; print it: `node ai/scripts/diagnostics/defectObservations.mjs`).
 - **Promotion runs the FULL ceremony** — an issue is created only on a production-down signal, an independent second occurrence, an operator escalation, or a triage decision, and runs this entire workflow, V-B-A included. Capture never waits for any of it.
-- **Recovery is a note too:** `defect-note: [recovered] <surface> broke <symptom>` closes the observation idempotently; a fresh sighting re-opens it. One standing record per fingerprint — never one note per sample.
+- **Recovery is a note too:** `defect-note: [recovered] <surface> broke <symptom>` closes the observation idempotently; a fresh sighting re-opens it.
 - **Promotion/dismissal are notes too:** `defect-note: [promoted #N] <same note>` (any seat) or `defect-note: [dismissed] <same note>` (operator only) — either takes a row off the orchestrator digest (`defectObservations.mjs --digest`).
-- The asymmetry is deliberate: a duplicate note costs one dedup; an unfiled defect costs what an unfiled production break costs (origin: the `query_summaries` specimen, D#17136). **A workaround without a filed defect-note is the named anti-pattern** — the workaround may stay private, the sighting may not.
+- The asymmetry is deliberate: a duplicate note costs one dedup; an unfiled defect costs what an unfiled production break costs (origin: the `query_summaries` specimen, D#17136). **A workaround or scope boundary without a filed defect-note is the named anti-pattern** — the workaround may stay private, the sighting may not. A comment promising two copies stay equal is a note nobody sent.
 
 ## 2. Six-Stage Challenge Chain
 

--- a/.agents/skills/ticket-create/references/ticket-create-workflow.md
+++ b/.agents/skills/ticket-create/references/ticket-create-workflow.md
@@ -91,7 +91,7 @@ defect-note: <surface> <broke | is wrong> <observed symptom>
 
 - **Capture ≠ admission.** Notes fold into one standing observation per surface/symptom fingerprint (read model: `ai/services/memory-core/helpers/defectObservationFold.mjs`; print it: `node ai/scripts/diagnostics/defectObservations.mjs`).
 - **Promotion runs the FULL ceremony** — an issue is created only on a production-down signal, an independent second occurrence, an operator escalation, or a triage decision, and runs this entire workflow, V-B-A included. Capture never waits for any of it.
-- **Recovery is a note too:** `defect-note: [recovered] <surface> broke <symptom>` closes the observation idempotently; a fresh sighting re-opens it.
+- **Recovery is a note too:** `defect-note: [recovered] <the note, verbatim>` closes the observation idempotently — the fold keys the whole line; a fresh sighting re-opens it.
 - **Promotion/dismissal are notes too:** `defect-note: [promoted #N] <same note>` (any seat) or `defect-note: [dismissed] <same note>` (operator only) — either takes a row off the orchestrator digest (`defectObservations.mjs --digest`).
 - The asymmetry is deliberate: a duplicate note costs one dedup; an unfiled defect costs what an unfiled production break costs (origin: the `query_summaries` specimen, D#17136). **A workaround or scope boundary without a filed defect-note is the named anti-pattern** — the workaround may stay private, the sighting may not.
 


### PR DESCRIPTION
Resolves #43

🌿 A channel whose written trigger admitted only breakage was carrying sightings anyway; now there is no way to say the door was too narrow, because the door is where the traffic already went.

Evidence: L2 (repo lint + full test suite run locally against this head, with a clean-`dev` control for the one pre-existing failure) → L2 required (both ACs are text-and-budget claims verifiable by running this repo's own guards). No residuals.

## The measurement that changed the shape of this change

The ticket proposed widening §1e's trigger. Before implementing, I measured whether the widening was hypothetical. Over the `neomjs/neo` A2A window 2026-09-04T01:00–03:30Z: **9** `defect-note:` broadcasts from two independent seats, of which **5** report substrate that never broke, and **0 of 9** use the template's verb `broke`.

So this is not a proposal. Two seats reached for a channel whose written trigger did not admit what they were filing, and the text is what is stale. That is the strongest form of the argument — the practice is already right.

## Deltas

| File | Change |
|---|---|
| `ticket-create/references/ticket-create-workflow.md` §1e | trigger names both conditions; the note template's verb slot becomes `<broke \| is wrong>`; the **recovery** template becomes `<the note, verbatim>` with the whole-line keying stated; the anti-pattern covers a scope boundary, not only a workaround; one restatement of the fold rule deleted |
| `pull-request/references/pull-request-workflow.md` §9 | one line: a knowingly-unfixed sighting in a file you touched costs `out of scope, noted in <defect-note\|#N>`, note filed first |

The fold, promotion rules and digest are untouched. The **grammar** moved on both arms — note and recovery — because the fold keys the whole line, so widening one arm without the other silently splits an observation in two. My first push made exactly that mistake and it was caught in review.

## Acceptance Criteria

| AC | Status | Evidence |
|---|---|---|
| AC-1 | ✅ | §1e reads *"On broken substrate — or working substrate you touched and saw is wrong — production or local"*, and the grammar moved on **both** arms: the note template's verb slot widened, and the recovery template became `<the note, verbatim>`. That second half was a review finding (@neo-opus-grace) and a real defect in the first push — `defectNoteFingerprint` hashes the whole normalized line, so a note filed on the widened arm could not be closed by a recovery line still saying `broke`. Verified by running the function: `67d88ad9…` vs `43f08946…`, closing only on a verbatim repeat. No new syntax for a human reader; the *reason* is now stated so a later editor does not reword the recovery. |
| AC-2 | ✅ | §9 gained one sentence, not a section. It fires only when the author knowingly left something unfixed; a body with nothing to declare declares nothing. |
| AC-3 | ✅ | **Two guards caught me and I paid both rather than invoking either escape.** (1) `npm run lint` rejected the first attempt at **25072 bytes**, over the **25000** per-file budget — offset by deleting *"One standing record per fingerprint — never one note per sample"*, which restates what **Capture ≠ admission** says one bullet above. (2) CI runs the same linter **`--base`**, a corpus net-growth gate I had not run locally, capping growth at **250**; mine was **353**. It offers `[skill-growth-justified: reason]`, and using that to keep prose I could cut is the unexamined growth it exists to stop — so I cut instead. After the RA-1 fix the gate ran again and rejected **291**; I trimmed my own consequence clause, which the stated reason already implies, rather than reach for the escape a second time. Final, both axes spelled out because one number was read as the other: `ticket-create` **24868 → 24914 = +46** (86 bytes under its per-file cap); `pull-request` **22167 → 22366 = +199**; **corpus net +245** against the 250 cap, which is the figure the gate judges. |
| AC-4 | ✅ | Retirement trigger stated below. |

**AC-4 — retirement trigger.** When `defectObservations.mjs --digest` shows touched-and-saw notes arriving from more than one seat across a sustained window, the clause has done its work and §1e's trigger compresses back to a single line naming both conditions without the explanatory half. The 9-note measurement above is the baseline that trigger is read against.

## Test Evidence

```
lint --base <merge-base>   skill-corpus: 37 skills, coherent with the manifest, within budget, document reach canonical.
npm test                   24/25 passed
CI                         all checks green
```

The one failure is pre-existing, not introduced: `git stash` → same suite on clean `dev` → **24/25**, then restored to 2 changed files. It is a dangling-symlink check unrelated to either file here.

**Reviewer note on my own process:** my first push was red because I ran `lint` without `--base` and never saw the net-growth gate. Running the repo's guards is not the same as running them the way CI does — the local invocation was a weaker instrument than the one that judges the PR, and I would not have known if CI had not disagreed with me.

## Why this arrived from another repository

It was filed as `neomjs/neo#18242` and I began implementing it there. In `neomjs/neo`, `.agents/skills` is a symlink into `node_modules/neo-agent-skills`, so those edits landed in a dependency directory — erased by the next `npm ci`, against a file this repo owns. Same custody class as `neomjs/neo#18228`.

Two things that only surfaced because of the move:

- The installed mirror is **stale**: `npm ls neo-agent-skills` reports `0.1.1 invalid: "^0.1.3" from the root project`, and its `ticket-create-workflow.md` was **1420 bytes** behind this one. Editing there would also have meant editing an out-of-date base. Broadcast as a defect-note — and it is itself a touched-and-saw sighting, which is what this PR makes filable.
- The ticket's evidence was **wrong and is now stronger**. Its problem statement claimed 12 `?.locked === true` reads, 3 `'unlock' : 'lock'` derivations, and 3 comments promising two copies stay equal. Measured: 11, and 4 + 2 `'restore' : 'maximize'` — six derivations of two mappings — and of the three `cannot drift` comments only `Workspace.mjs:1763` is that species; the others are a single-reader claim and a persistence boundary. Corrected on #43 before this branch existed.

## Residual / Post-Merge Validation

- Two defect-notes filed from this PR's own review, both under the clause it adds: the grammar's **two homes** (§1e here, the `@module` header of `defectObservationFold.mjs:19-23` in `neomjs/neo-agent-brain`), and `parseDefectNote` splitting on the literal `' broke '` so every live note parses as `false` and every digest row prints `(unparsed note)`. Neither is this PR's to fix; the second is a consequence of this PR's widening and belongs on the record beside it.
- Consumers read this through the published package, so the widened trigger reaches a seat only after a release and an install. Any checkout pinned below the release keeps the narrow trigger with no signal at the read — the same skew the defect-note above reports.

— Vega (Opus 5, Claude Code) 🌿
