### PR TITLE
docs(skills): seat budget discipline becomes a trigger-loaded payload (#49)

### DIFF
--- a/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
+++ b/.agents/skills/post-review-pickup/references/post-review-pickup-workflow.md
@@ -31,6 +31,8 @@ file or route the bug, then continue picking the next lane.
 
 ## 2. Sibling payloads (read on trigger only)
 
+<!-- trigger: lane selection or a wake turn on a weekly-capped seat → read ./seat-budget-discipline.md -->
+
 <!-- trigger: fresh-session/watchdog review intake with no active author lane → read ./pre-review-intake-lane-gate.md before loading /pr-review -->
 - [`./pre-review-intake-lane-gate.md`](./pre-review-intake-lane-gate.md) — when
   role payloads must be read before lane choice, and when review-first is

--- a/.agents/skills/post-review-pickup/references/seat-budget-discipline.md
+++ b/.agents/skills/post-review-pickup/references/seat-budget-discipline.md
@@ -1,0 +1,76 @@
+# Seat Budget Discipline (weekly-capped seats)
+
+Loaded on trigger from lane selection, a wake turn, PR composition, and reviewer routing. Every
+rule here is `keep` inside this payload and `DISCIPLINE-ONLY` unless tagged otherwise. The
+authority is two operator rulings, cited by date; nothing here is a seat's private habit.
+
+## 1. The constraint, measured
+
+- **The cap is the provider's, not ours.** Anthropic's Max plans meter Fable separately — "You
+  can use up to 50% of your weekly usage limits on Fable models at no extra cost"
+  (support.claude.com article 15424964, current on 2026-09-04); the panel's `Weekly · Fable` line
+  shows that half (68% there means 68% of it). OpenAI markets against exactly this (GPT-6 Astra /
+  Codex campaign, 2026-09-03: "100% of the allocation towards Astra", plus a daily bank reset) —
+  the flagship budget per plan-dollar differs by more than 2× between the benches, a routing fact.
+- **Dated change, 2026-09-14 (@ClaudeDevs on X, quoted by BleepingComputer 2026-08-29):** the
+  standard weekly limit becomes a permanent +25% over the pre-May baseline, replacing the
+  temporary +50% boost that runs through 2026-09-13 — about 17% less than today. The Fable half is
+  a share of that limit, so the Fable pair's week shrinks by the same ~17%; the pace in §2 holds on
+  the smaller week. A report that the separate Fable meter goes on the same date has no official
+  source and the Fable-plan article contradicts it: not a fact, do not plan on it.
+- **2026-08-15 (operator):** "pace, don't sprint" — Fable had burned 63% of its allocation in 17 h;
+  the full team could drain the pro20 in ~3 days. Anthropic hands out extra weekly resets rarely
+  (one at the Fable 5.1 release, ~2 months without one before, none for Opus 5): **the Friday reset
+  is the only clock — never plan around a rescue.** Codex seats get one every ~2.6 days.
+- **2026-09-04 (operator panel):** weekly Fable **68% after 24 seat-hours** (two seats, one day);
+  a pro10 Fable seat 61%; the GPT pair 38% over the same hours with a daily bank reset. At that
+  rate the Fable seats go dark after 2–3 days of the week — the second such day; the pacing rule
+  had lived in per-seat memories only.
+- **The burn is context length × tool-call count.** Every call carries the whole context; a
+  session of ~300 calls over hours carries hundreds of K each time. Named waste from one seat-day:
+  full-file reads where a region would do, a 50-item mailbox listing in context, a reviewer's
+  review read twice, the unit suite five times and the focused specs six times for one lane, five
+  real stage runs, three review rounds on one PR whose findings were boundary tests the author
+  could have written before opening.
+
+## 2. Pacing (the cap, made daily)
+
+Agents cannot read the usage panel; the operator can. Pace the `Weekly · Fable` meter as **≈ 10
+points per day for the pair (≈ 5 per seat)** across the Friday-to-Friday week (from 2026-09-14
+the same pace on a ~17% smaller week). A burst day over
+20 points means dark seats before the reset. When the operator posts the panel numbers (an A2A budget
+pulse or a paired message), they outrank every plan: over pace → finish the gated obligation,
+save, stop.
+
+## 3. Rules
+
+1. **Bounded shifts.** Finish the gated obligation, save, stop; no lane-chaining across a day. A
+   wake turn is a full-context call: do only the obligation that woke you, no exploratory reads.
+2. **Region reads.** `Read` with offset/limit, grep windows; never a full file for an Edit gate;
+   mailbox `limit` ≤ 10 (`MACHINE-ENFORCEABLE-CANDIDATE`); never re-read an artifact already in
+   context — cite it.
+3. **One batched command per round.** The focused spec while iterating; the full unit suite **once**
+   before the push (`MACHINE-ENFORCEABLE-CANDIDATE`); the real e2e / stage run once, at the head.
+4. **Compose for first-cycle approval.** Before the PR opens, the reviewer's falsifier at every
+   consumed boundary is an ARM — the integration seam, the collision, the provenance, the
+   shipped-metadata leak. The author-side review round is the most expensive token on both seats.
+5. **Sub-agents, by seat.** Claude seats (1M context): **forbidden and unneeded** — measured at
+   ~120 K tokens in 10 minutes against 30–50 K/h for a main agent; an idle of ~2 h loses the prompt
+   cache on a long session. GPT seats (Codex caps context at 258 K): **necessary and affordable**.
+   The same question gets opposite correct answers, decided by context × billing.
+6. **Review routing (the family default).** Opus seats review GPT-authored PRs; GPT seats review
+   Claude-authored PRs (their bank resets daily). An Opus or Fable seat takes a Claude-authored PR
+   only when it is important AND semantically close to its own lane. The cross-family mandate
+   stays the gate; this rule orders the choice.
+
+## 4. Open measurement
+
+Fresh session every ~2 h (one recovery each, small context) versus one long session with
+compactions: **untested.** Measure one seat, one day each way, similar work, the operator's panel
+before and after; record the delta here. Until then, §3.1 stands on the arithmetic alone.
+
+## 5. Sunset
+
+Retire the 50% line in §1 when the Fable-plan support article stops stating it; retire §2 when seats can read their plan usage themselves (a budget-pulse tool); retire §3.5 when
+a Claude sub-agent measurement contradicts the 2026 numbers; the routing rule (§3.6) also lives
+inline in `ci-green-review-routing.md` and survives this file.

--- a/.agents/skills/pull-request/references/ci-green-review-routing.md
+++ b/.agents/skills/pull-request/references/ci-green-review-routing.md
@@ -36,7 +36,7 @@ change it. Activation uses live `mergeable`; elsewhere
 
 All required checks for the current head passed.
 
-1. Choose exactly one `primary-reviewer` using the normal routing heuristic.
+1. Choose exactly one `primary-reviewer` using the normal routing heuristic — family default: Opus seats review GPT-authored PRs, GPT seats review Claude-authored PRs; the exception and its rationale: `../../post-review-pickup/references/seat-budget-discipline.md` §3.6.
 2. Call `manage_pr_reviewers({action: 'add', pr_number, reviewers: ['<reviewer>']})`.
 3. Send one targeted A2A DM to the same reviewer.
 4. Include:

--- a/.agents/skills/pull-request/references/pull-request-workflow.md
+++ b/.agents/skills/pull-request/references/pull-request-workflow.md
@@ -4,6 +4,8 @@ This is the authoritative PR protocol for every agent. PR creation is an archite
 
 ## 1. The "Stepping Back" Reflection Protocol (Pre-Commit Gate)
 
+<!-- trigger: composing a PR on a weekly-capped seat → read ../../post-review-pickup/references/seat-budget-discipline.md before the PR opens -->
+
 Before the final `git commit` and `gh pr create`—an irreversible handoff—step back and act as an Architect.
 
 **Scope Creep vs. Iteration:**


### PR DESCRIPTION
Resolves #49

Anthropic meters Fable at 50% of a Max plan's weekly allocation (the `Weekly · Fable` line — OpenAI markets against exactly that meter in the GPT-6 Astra campaign); on 2026-09-14 the standard weekly limit lands ~17% below today's boosted level (a @ClaudeDevs post, quoted by BleepingComputer 2026-08-29), so the Fable half shrinks with it — the report that the separate Fable meter goes that day has no official source, and the payload says so; the operator's pacing ruling (2026-08-15, "pace, don't sprint") and today's rulings (2026-09-04: codify it, the sub-agent measurement, the family review routing) become substrate every seat loads: one World-Atlas payload, `post-review-pickup/references/seat-budget-discipline.md`, behind three one-line triggers at the moments it governs — lane selection or a wake turn, composing a PR, choosing the reviewer. It had lived in per-seat memories and was broken twice (63% in 17 h, 68% in 24 seat-hours).

Evidence: L2 (substrate: `npm run lint` corpus coherence + `npm test`; the load effect measured as bytes) → L2 required (AC-1…AC-4); AC-5 is post-merge, operator-witnessed on a consumer boot. Residual: none.

## AC Evidence
| AC | Evidence |
|---|---|
| AC-1 | the payload: §1 the provider meter quoted from support article 15424964, the sourced 2026-09-14 change with the unsourced Fable-meter report negated, and both operator dates, §2 the cap paced daily (≈ 10 points/day for the pair), §3 the six rules with `DISCIPLINE-ONLY` / `MACHINE-ENFORCEABLE-CANDIDATE` tags (mailbox limit, one full run per push), §3.5 the sub-agent symmetry (Claude 1M forbidden-and-unneeded, GPT 258 K necessary-and-affordable), §3.6 the routing, §4 the open session-length measurement, §5 the sunset clause. |
| AC-2 | three triggers, one line each: `post-review-pickup-workflow.md` §2 (lane selection / wake), `pull-request-workflow.md` §1 (composing a PR), `ci-green-review-routing.md` §3 step 1 (the routing default inline — part of the heuristic, not an edge case). Always-loaded delta across the three Maps: 534 bytes; no rule body in a Map. |
| AC-3 | `npm run lint` → skill-corpus: 37 skills, coherent with the manifest, within budget, document reach canonical.; `npm test` → 24/25 — the one red (`a clean non-Neo consumer resolves projected document references`, materialization check FAILED (38)) is identical on a clean `dev` tree with this change stashed; CI is the receipt. |
| AC-4 | the load-effect audit below. |
| AC-5 | Post-Merge Validation. |

## /turn-memory-pre-flight load-effect audit
- **Placement (decision tree Step 2):** a rule governing identifiable lifecycle events — lane selection, PR composition, reviewer choice — is skill substrate behind triggers, never `AGENTS.md`.
- **Map vs Atlas:** the three workflow files stay Maps and gain one trigger line each (`compress-to-trigger`); the body lives in the Atlas payload, loaded only when a trigger fires. Net always-loaded delta: 534 bytes across three files; payload 5529 bytes, trigger-loaded.
- **Slot rule:** trigger-frequency = the three moments (edge-case-triggered); failure-severity = seats dark mid-week; enforceability = discipline today, two rows tagged as hook candidates.
- **Decay mitigation:** §5 names the sunsets (a budget-pulse tool retires the pacing section; a contradicting sub-agent measurement retires §3.5; the routing line survives in the routing file).
- **Mechanical pre-flight:** the skills repository is consumed through `neo-agent-skills-materialize`; the corpus lint registers the new payload (`document reach canonical`). No harness hook file changes.

## Deltas from ticket
None substantive — the ticket's ledger rows 1–4 are the diff.

## Test Evidence
All coverage runs in CI (the corpus lint and the runner suite); the byte deltas above are the only outside-CI measurement.

## Post-Merge Validation
- [ ] After the next `neo-agent-skills` publish or a consumer's `neo-agent-skills-materialize`, the three trigger lines appear in the consumer's materialized `.agents/skills` (operator-witnessed on one seat boot).

## Commits
- `3ec9d37` — the payload and the three triggers; the commit carries the `[skill-growth-justified: …]` trailer the corpus net-growth arm requires (trigger-loaded, sunsets named).

Authored by Clio (Claude Fable 5.1, Claude Code). Session 46962d8b-08f3-49a3-8049-d74e2052af37.
