### PR TITLE
chore(release): prepare the 0.1.4 package and baseline pins (#44)

### DIFF
--- a/.github/workflows/reusable-pr-baseline.yml
+++ b/.github/workflows/reusable-pr-baseline.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Install immutable archaeology guard
         env:
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-source-comment-archaeology
-          SKILLS_VERSION: '0.1.3'
+          SKILLS_VERSION: '0.1.4'
         run: >-
           npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
           "neo-agent-skills@${SKILLS_VERSION}"
@@ -135,7 +135,7 @@ jobs:
       - name: Install immutable substrate guard
         env:
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-substrate-size
-          SKILLS_VERSION: '0.1.3'
+          SKILLS_VERSION: '0.1.4'
         run: >-
           npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
           "neo-agent-skills@${SKILLS_VERSION}"
@@ -180,7 +180,7 @@ jobs:
       - name: Install immutable PR-body guard
         env:
           SKILLS_ROOT: ${{ runner.temp }}/neo-agent-skills-pr-body
-          SKILLS_VERSION: '0.1.3'
+          SKILLS_VERSION: '0.1.4'
         run: >-
           npm install --prefix "${SKILLS_ROOT}" --ignore-scripts --package-lock=false --no-save
           "neo-agent-skills@${SKILLS_VERSION}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name"       : "neo-agent-skills",
-    "version"    : "0.1.3",
+    "version"    : "0.1.4",
     "description": "The canonical agent skill substrate for the neomjs organization. Consumers depend on it; they never copy it.",
     "type"       : "module",
     "license"    : "MIT",


### PR DESCRIPTION
Resolves #44

Prepare `neo-agent-skills@0.1.4` for publication. The registry and `dev` both identify as `0.1.3`, while `dev` contains unpublished skill changes. This PR changes `package.json` and all three corresponding `SKILLS_VERSION` pins in the reusable baseline from `0.1.3` to `0.1.4`.

## AC Evidence

This is the release-preparation portion of #44. The operator-directed sequence is **merge #53, merge #55, then publish `0.1.4` from the resulting `dev`**. #56 owns automatic publication and future bump enforcement; neither is implemented here. Merging prepares the combined release; publication remains the operator's next step.

Evidence: L2 (exact-head corpus, package and workflow contract checks) → L2 required for release preparation. Registry availability is a separate operator release receipt, still outstanding.

All three surveyed package consumers use `^0.1.3`, which admits `0.1.4` but excludes `0.2.0`. Existing lockfiles still require an update to select the new artifact; changing a version number does not update an installed seat.

The author's installed-versus-dev comparison found six changed workflow references (90 changed lines) and the new allowlisted `check-workflow-concurrency.mjs` missing from the published package. Source-only test scripts are deliberately outside the package allowlist. Those observations motivate the release; this diff changes no corpus content.

## Test Evidence

Current-head `corpus` CI is green at `e662330a9ce1a623208b7ebf385dc2f26fab62d1`, including the reusable-baseline contract and 42 negative mutations, package contents, and clean-consumer materialization.

The first bump-only commit failed the three package/pin coherence assertions. The second commit updates all install pins, preserving that contract. The author's local 24/25 result also occurred on the clean base; current-head CI provides the complete source-suite receipt.

## Release Sequence

1. Merge #53.
2. Merge this PR; the resulting `dev` contains both the skill repairs and the coordinated version/pin bump.
3. The operator publishes `0.1.4` from that updated `dev` and records the registry receipt on #44.

Publication before merge is not required. Publication precedes consumer adoption of the new reusable-workflow revision.

## Post-Merge Validation

- [ ] Before a consumer adopts this new reusable-workflow revision, verify that `neo-agent-skills@0.1.4` resolves. Then update its immutable workflow coordinate and package lockfile as applicable.

Existing callers remain on immutable workflow SHAs. The engine currently pins `e409dea5dcbc9f6f97d6eb86ecbef4caa7a269b8`; the institution pins `7c9bd16f97a9b58309602431fc5b5741bf818e22`. Both referenced baseline revisions install `0.1.3`. This PR changes neither caller coordinate, so merging it does not immediately redirect those installs.

The unavailable-pin hazard applies to callers adopting the **new** revision before publication. At review time, `0.1.3` resolves and `0.1.4` returns E404. Publishing from the reviewed branch before adoption avoids that gap. A future publish-on-merge workflow is asynchronous; its existence alone would not prove that publication precedes adoption.

## Deltas

- `package.json`: +1 / −1.
- `.github/workflows/reusable-pr-baseline.yml`: +3 / −3.
- No new runtime, loader, skill payload, or publish workflow.

Author origin session: `70502f9a-5b14-4dcf-bcdf-4a29b546df77`.

Maintainer review correction: the source prepares publication; it does not execute it. The earlier blanket claim that merging immediately changes every consumer was disproved by the callers' immutable coordinates. The earlier pre-merge publication requirement was withdrawn after the operator clarified the merge-then-publish sequence. Actual publication is still reported separately from source preparation.
